### PR TITLE
Allow manual trigger of nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,10 @@
 name: nightly build
 
 on:
+  repository_dispatch:
+    types: [nightly-build]
   schedule:
     - cron:  '0 10 * * *'
-
-  check_suite:
-    types: [rerequested]
 
 jobs:
   build:


### PR DESCRIPTION
## Description ##
This PR allows manual triggering of the nightly build. We can use the following command to trigger the night build. 

curl -XPOST -u "USERNAME:PERSONAL_TOKEN" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/USERNAME/REPOSITORY_NAME/dispatches --data '{"event_type": “nightly-build"}'

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change
