### PR TITLE
Correction/clarification of the doc of batchFlatten

### DIFF
--- a/api/src/main/java/ai/djl/nn/Blocks.java
+++ b/api/src/main/java/ai/djl/nn/Blocks.java
@@ -25,13 +25,12 @@ public final class Blocks {
     }
 
     /**
-     * Flattens the only {@link ai.djl.ndarray.NDArray} in the input to a 2-D {@link
-     * ai.djl.ndarray.NDArray} of shape (batch, size).
+     * Inflates the 1-D flattened {@link ai.djl.ndarray.NDArray} provided as input to a 2-D {@link ai.djl.ndarray.NDArray} of shape (batch, size).
      *
-     * @param array a singleton {@link NDList}
+     * @param array a 1-D flattened array of size batch * size {@link NDList}
      * @param batch the batch size
-     * @param size the size of the flattened array
-     * @return a singleton {@link NDList} that contains the flattened {@link ai.djl.ndarray.NDArray}
+     * @param size the dimension of the input
+     * @return a 2-D {@link NDList} that contains the inflated {@link ai.djl.ndarray.NDArray}
      * @throws IndexOutOfBoundsException if the input {@link NDList} has more than one {@link
      *     ai.djl.ndarray.NDArray}
      */

--- a/api/src/main/java/ai/djl/nn/Blocks.java
+++ b/api/src/main/java/ai/djl/nn/Blocks.java
@@ -25,7 +25,8 @@ public final class Blocks {
     }
 
     /**
-     * Inflates the 1-D flattened {@link ai.djl.ndarray.NDArray} provided as input to a 2-D {@link ai.djl.ndarray.NDArray} of shape (batch, size).
+     * Inflates the 1-D flattened {@link ai.djl.ndarray.NDArray} provided as input to a 2-D {@link
+     * ai.djl.ndarray.NDArray} of shape (batch, size).
      *
      * @param array a 1-D flattened array of size batch * size {@link NDList}
      * @param batch the batch size


### PR DESCRIPTION
## Description ##

It seems that the documentation of the `batchFlatten` method in class `Blocks`, [at this URL](https://github.com/awslabs/djl/blob/fadf64824036d9c570c7a98a559f92989639f47a/api/src/main/java/ai/djl/nn/Blocks.java#L38), is not correct. Normally one deals with "flattening" a data structure when converting it from multi-dimensional to one-dimensional. If I have well understood the purpose of this method, the input is a a flattened (1-D array) and one wants to "inflate" it to get a (batch, size)-shape array, i.e. to batch a flattened batch of inputs that comes in the form of a 1-D array. The original description of this method seemed misleading.  Also, term "singleton" was confusing, I simply replaced it by "1-D array". 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

