### PR TITLE
Documentation of DefaultTrainingConfig outdated

### DIFF
--- a/api/src/main/java/ai/djl/training/DefaultTrainingConfig.java
+++ b/api/src/main/java/ai/djl/training/DefaultTrainingConfig.java
@@ -38,7 +38,10 @@ public class DefaultTrainingConfig implements TrainingConfig {
     private int batchSize;
 
     /**
-     * Creates an instance of {@code DefaultTrainingConfig} with the given {@link Initializer}.
+     * Creates an instance of {@code DefaultTrainingConfig} with the given {@link Loss}. {@code
+     * DefaultTrainingConfig} creates a default {@link TrainingConfig} with the {@link
+     * XavierInitializer} as initialiser, {@link Adam} as optimiser, and the given {@link Loss}. The
+     * evaluators and listeners are left to the user's discretion.
      *
      * @param loss the loss to use for training
      */


### PR DESCRIPTION
## Description ##

It seems that the `DefaultTrainingConfig`'s constructor, [at this URL](https://github.com/awslabs/djl/blob/03794b71c83b3e1292546c7d3ea942fb839506ce/api/src/main/java/ai/djl/training/DefaultTrainingConfig.java#L45), has changed, it takes now solely a `Loss` object as argument, and not an `Initializer` anymore. I have therefore changed and improved its documentation to comply with its new version.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

