### PR TITLE
Improve docs

### DIFF
--- a/api/src/main/java/ai/djl/nn/convolutional/Conv1D.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv1D.java
@@ -17,7 +17,17 @@ import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 
 /**
- * Computes 1-D convolution on 3-D input.
+ * <p>A {@code Conv1D} layer works similar to {@link Convolution} layer with the exception of the
+ * number of dimension it operates on being only one, which is {@link LayoutType#WIDTH}. The
+ * channel of the input data may be more than one, depending on what data is processed. Each
+ * filter slides through the data with only one direction of movement along the dimension itself.
+ *
+ * <p>Commonly, this kind of convolution layer, as proposed in this
+ * <a href="https://ieeexplore.ieee.org/document/7318926/">paper</a> is used in tasks utilizing
+ * serial data, enabling convolutional processing of 1-dimensional data such as time-series data
+ * (stock price, weather, ECG) and text/speech data without the need of transforming it to
+ * 2-dimensional data to be processed by {@link Conv2D}, though this is quite a common technique
+ * as well.
  *
  * <p>The input to a {@code Conv1D} is an {@link ai.djl.ndarray.NDList} with a single 3-D {@link
  * ai.djl.ndarray.NDArray}. The layout of the {@link ai.djl.ndarray.NDArray} must be "NCW". The

--- a/api/src/main/java/ai/djl/nn/convolutional/Conv1D.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv1D.java
@@ -17,17 +17,16 @@ import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 
 /**
- * <p>A {@code Conv1D} layer works similar to {@link Convolution} layer with the exception of the
- * number of dimension it operates on being only one, which is {@link LayoutType#WIDTH}. The
- * channel of the input data may be more than one, depending on what data is processed. Each
- * filter slides through the data with only one direction of movement along the dimension itself.
+ * A {@code Conv1D} layer works similar to {@link Convolution} layer with the exception of the
+ * number of dimension it operates on being only one, which is {@link LayoutType#WIDTH}. The channel
+ * of the input data may be more than one, depending on what data is processed. Each filter slides
+ * through the data with only one direction of movement along the dimension itself.
  *
- * <p>Commonly, this kind of convolution layer, as proposed in this
- * <a href="https://ieeexplore.ieee.org/document/7318926/">paper</a> is used in tasks utilizing
- * serial data, enabling convolutional processing of 1-dimensional data such as time-series data
- * (stock price, weather, ECG) and text/speech data without the need of transforming it to
- * 2-dimensional data to be processed by {@link Conv2D}, though this is quite a common technique
- * as well.
+ * <p>Commonly, this kind of convolution layer, as proposed in this <a
+ * href="https://ieeexplore.ieee.org/document/7318926/">paper</a> is used in tasks utilizing serial
+ * data, enabling convolutional processing of 1-dimensional data such as time-series data (stock
+ * price, weather, ECG) and text/speech data without the need of transforming it to 2-dimensional
+ * data to be processed by {@link Conv2D}, though this is quite a common technique as well.
  *
  * <p>The input to a {@code Conv1D} is an {@link ai.djl.ndarray.NDList} with a single 3-D {@link
  * ai.djl.ndarray.NDArray}. The layout of the {@link ai.djl.ndarray.NDArray} must be "NCW". The

--- a/api/src/main/java/ai/djl/nn/convolutional/Conv2D.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv2D.java
@@ -17,20 +17,19 @@ import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 
 /**
- * <p>Being the pioneer of convolution layers, {@code Conv2D} layer works on two dimensions of
- * input, {@link LayoutType#WIDTH} and {@link LayoutType#HEIGHT} as usually a {@code Conv2D}
- * layer is used to process data with two spatial dimensions, namely image. The concept itself
- * works just as how {@link Convolution} does, and each filter slides through an input data by
- * two directions, first traversing the {@link LayoutType#WIDTH} then traverses each row of the
- * data.
+ * Being the pioneer of convolution layers, {@code Conv2D} layer works on two dimensions of input,
+ * {@link LayoutType#WIDTH} and {@link LayoutType#HEIGHT} as usually a {@code Conv2D} layer is used
+ * to process data with two spatial dimensions, namely image. The concept itself works just as how
+ * {@link Convolution} does, and each filter slides through an input data by two directions, first
+ * traversing the {@link LayoutType#WIDTH} then traverses each row of the data.
  *
- * <p>First proposed by LeCun <i>et al.</i>'s <a href="http://yann.lecun.com/exdb/publis/pdf/lecun-01a.pdf">
- * paper</a>, 2-dimensional convolution layer gained its rising interest with the publication of
- * <a href="https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf">
- * paper</a> about AlexNet for image classification task. It is still commonly used in
- * image-related tasks and adapted in other tasks, including but not limited to 1-dimensional
- * data which may be transformed to 2-dimensional data, though {@link Conv1D} is now available
- * for use.
+ * <p>First proposed by LeCun <i>et al.</i>'s <a
+ * href="http://yann.lecun.com/exdb/publis/pdf/lecun-01a.pdf">paper</a>, 2-dimensional convolution
+ * layer gained its rising interest with the publication of <a
+ * href="https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf">
+ * paper</a> about AlexNet for image classification task. It is still commonly used in image-related
+ * tasks and adapted in other tasks, including but not limited to 1-dimensional data which may be
+ * transformed to 2-dimensional data, though {@link Conv1D} is now available for use.
  *
  * <p>The input to a {@code Conv2D} is an {@link ai.djl.ndarray.NDList} with a single 4-D {@link
  * ai.djl.ndarray.NDArray}. The layout of the {@link ai.djl.ndarray.NDArray} must be "NCHW". The

--- a/api/src/main/java/ai/djl/nn/convolutional/Conv2D.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv2D.java
@@ -17,7 +17,20 @@ import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 
 /**
- * Computes 2-D convolution on 4-D input.
+ * <p>Being the pioneer of convolution layers, {@code Conv2D} layer works on two dimensions of
+ * input, {@link LayoutType#WIDTH} and {@link LayoutType#HEIGHT} as usually a {@code Conv2D}
+ * layer is used to process data with two spatial dimensions, namely image. The concept itself
+ * works just as how {@link Convolution} does, and each filter slides through an input data by
+ * two directions, first traversing the {@link LayoutType#WIDTH} then traverses each row of the
+ * data.
+ *
+ * <p>First proposed by LeCun <i>et al.</i>'s <a href="http://yann.lecun.com/exdb/publis/pdf/lecun-01a.pdf">
+ * paper</a>, 2-dimensional convolution layer gained its rising interest with the publication of
+ * <a href="https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf">
+ * paper</a> about AlexNet for image classification task. It is still commonly used in
+ * image-related tasks and adapted in other tasks, including but not limited to 1-dimensional
+ * data which may be transformed to 2-dimensional data, though {@link Conv1D} is now available
+ * for use.
  *
  * <p>The input to a {@code Conv2D} is an {@link ai.djl.ndarray.NDList} with a single 4-D {@link
  * ai.djl.ndarray.NDArray}. The layout of the {@link ai.djl.ndarray.NDArray} must be "NCHW". The

--- a/api/src/main/java/ai/djl/nn/convolutional/Conv3D.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv3D.java
@@ -17,7 +17,18 @@ import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 
 /**
- * Computes 3-D convolution on 5-D input.
+ * <p>{@code Conv3D} layer behaves just as {@link Convolution} does, with the distinction being it
+ * operates of 3-dimensional data such as medical images or video data. The traversal of
+ * each filter begins from {@link LayoutType#WIDTH} then to {@link LayoutType#HEIGHT}, and lastly
+ * across each {@link LayoutType#DEPTH} in the specified {@code depth} size of the data.
+ *
+ * <p>The utilization of {@code Conv3D} layer allows deeper analysis of visual data such as those
+ * in medical images, or even analysis on temporal data such as video data as a whole instead of
+ * processing each frame with a {@link Conv2D} layer, despite this being a common practice in
+ * computer vision researches. The benefit of utilizing this kind of layer is the maintaining of
+ * serial data across 2-dimensional data, hence could be beneficial for research focus on such as
+ * object tracking. The drawback is that this kind of layer is more costly compared to other
+ * convolution layer types since dot product operation is performed on all three dimensions.
  *
  * <p>The input to a {@code Conv3D} is an {@link ai.djl.ndarray.NDList} with a single 5-D {@link
  * ai.djl.ndarray.NDArray}. The layout of the {@link ai.djl.ndarray.NDArray} must be "NCDHW". The

--- a/api/src/main/java/ai/djl/nn/convolutional/Conv3D.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv3D.java
@@ -17,13 +17,13 @@ import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 
 /**
- * <p>{@code Conv3D} layer behaves just as {@link Convolution} does, with the distinction being it
- * operates of 3-dimensional data such as medical images or video data. The traversal of
- * each filter begins from {@link LayoutType#WIDTH} then to {@link LayoutType#HEIGHT}, and lastly
- * across each {@link LayoutType#DEPTH} in the specified {@code depth} size of the data.
+ * {@code Conv3D} layer behaves just as {@link Convolution} does, with the distinction being it
+ * operates of 3-dimensional data such as medical images or video data. The traversal of each filter
+ * begins from {@link LayoutType#WIDTH} then to {@link LayoutType#HEIGHT}, and lastly across each
+ * {@link LayoutType#DEPTH} in the specified {@code depth} size of the data.
  *
- * <p>The utilization of {@code Conv3D} layer allows deeper analysis of visual data such as those
- * in medical images, or even analysis on temporal data such as video data as a whole instead of
+ * <p>The utilization of {@code Conv3D} layer allows deeper analysis of visual data such as those in
+ * medical images, or even analysis on temporal data such as video data as a whole instead of
  * processing each frame with a {@link Conv2D} layer, despite this being a common practice in
  * computer vision researches. The benefit of utilizing this kind of layer is the maintaining of
  * serial data across 2-dimensional data, hence could be beneficial for research focus on such as

--- a/api/src/main/java/ai/djl/nn/convolutional/Convolution.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Convolution.java
@@ -32,7 +32,45 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Computes N-D convolution on (N+2)-D input. */
+/**
+ * <p>A convolution layer does a dot product calculation on each channel of \(k\)-channel input
+ * data by specified number of filters, each containing \(k\) kernels for calculating each
+ * channel in the input data and then summed per filter, hence the number of filters denote the
+ * number of output channels of a convolution layer. Some modifications may be set on a
+ * convolution layer, namely stride which shows the distance between each convolved input data in
+ * a channel, and padding which shows the preservation of input size (width and/or height and/or
+ * depth) by adding specified padding to the sides of the output. A convolution layer extracts
+ * features of input data with different representations where each representation lies per
+ * channel in the output, often known as feature map or feature vector.
+ *
+ * <p>While convolution process itself has been around for quite some time in mathematics, in 1998
+ * LeCun <i>et al.</i> implemented the very first convolution layers forming a network called
+ * LeNet-5 for character recognition task; details of the network's implementation can be find in
+ * LeNet-5's <a href="http://yann.lecun.com/exdb/publis/pdf/lecun-01a.pdf">paper</a>. When other
+ * approaches at that time used handcrafted features with external stage of feature extraction,
+ * convolution layer performed feature extraction on its own with no human interference. This
+ * marks a new era of machine-extracted features, but it was not until 2012 that the published
+ * <a href="https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf">
+ * paper</a> of AlexNet marked the beginning of convolutional neural networks, which by the name
+ * itself heavily relies on convolution layer.
+ *
+ * <p>Convolution layer is usually used in image-related tasks due to its well-renowned performance
+ * as shown by existing works and currently, other non-image-related fields of study are
+ * beginning to incorporate convolution layer as an addition or replacement of previous
+ * approaches, with one example being time series processing with 1-dimensional convolution layer.
+ * Due to the nature of convolution that processes all points in the input data, it is
+ * computationally expensive, hence the use of GPU is strongly recommended for faster performance
+ * as opposed to using CPU. Note that it is also common to stack convolution layers with
+ * different output channels for more representations of the input data.
+ *
+ * <p>Current implementations of {@code Convolution} are {@link Conv1D} with input dimension of
+ * {@link LayoutType#WIDTH}, {@link Conv2D} with input dimension of {@link LayoutType#WIDTH} and
+ * {@link LayoutType#HEIGHT}, and lastly {@link Conv3D} with input dimension of
+ * {@link LayoutType#WIDTH}, {@link LayoutType#HEIGHT}, and {@link LayoutType#DEPTH}. These
+ * implementations share the same core principal as a {@code Convolution} layer does, with the
+ * difference being the number of input dimension each operates on as denoted by {@code ConvXD}
+ * for {@code X} dimension(s).
+ */
 public abstract class Convolution extends ParameterBlock {
 
     private static final byte VERSION = 2;

--- a/api/src/main/java/ai/djl/nn/convolutional/Convolution.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Convolution.java
@@ -33,43 +33,43 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * <p>A convolution layer does a dot product calculation on each channel of \(k\)-channel input
- * data by specified number of filters, each containing \(k\) kernels for calculating each
- * channel in the input data and then summed per filter, hence the number of filters denote the
- * number of output channels of a convolution layer. Some modifications may be set on a
- * convolution layer, namely stride which shows the distance between each convolved input data in
- * a channel, and padding which shows the preservation of input size (width and/or height and/or
- * depth) by adding specified padding to the sides of the output. A convolution layer extracts
- * features of input data with different representations where each representation lies per
- * channel in the output, often known as feature map or feature vector.
+ * A convolution layer does a dot product calculation on each channel of \(k\)-channel input data by
+ * specified number of filters, each containing \(k\) kernels for calculating each channel in the
+ * input data and then summed per filter, hence the number of filters denote the number of output
+ * channels of a convolution layer. Some modifications may be set on a convolution layer, namely
+ * stride which shows the distance between each convolved input data in a channel, and padding which
+ * shows the preservation of input size (width and/or height and/or depth) by adding specified
+ * padding to the sides of the output. A convolution layer extracts features of input data with
+ * different representations where each representation lies per channel in the output, often known
+ * as feature map or feature vector.
  *
  * <p>While convolution process itself has been around for quite some time in mathematics, in 1998
  * LeCun <i>et al.</i> implemented the very first convolution layers forming a network called
  * LeNet-5 for character recognition task; details of the network's implementation can be find in
  * LeNet-5's <a href="http://yann.lecun.com/exdb/publis/pdf/lecun-01a.pdf">paper</a>. When other
  * approaches at that time used handcrafted features with external stage of feature extraction,
- * convolution layer performed feature extraction on its own with no human interference. This
- * marks a new era of machine-extracted features, but it was not until 2012 that the published
- * <a href="https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf">
+ * convolution layer performed feature extraction on its own with no human interference. This marks
+ * a new era of machine-extracted features, but it was not until 2012 that the published <a
+ * href="https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf">
  * paper</a> of AlexNet marked the beginning of convolutional neural networks, which by the name
  * itself heavily relies on convolution layer.
  *
  * <p>Convolution layer is usually used in image-related tasks due to its well-renowned performance
- * as shown by existing works and currently, other non-image-related fields of study are
- * beginning to incorporate convolution layer as an addition or replacement of previous
- * approaches, with one example being time series processing with 1-dimensional convolution layer.
- * Due to the nature of convolution that processes all points in the input data, it is
- * computationally expensive, hence the use of GPU is strongly recommended for faster performance
- * as opposed to using CPU. Note that it is also common to stack convolution layers with
- * different output channels for more representations of the input data.
+ * as shown by existing works and currently, other non-image-related fields of study are beginning
+ * to incorporate convolution layer as an addition or replacement of previous approaches, with one
+ * example being time series processing with 1-dimensional convolution layer. Due to the nature of
+ * convolution that processes all points in the input data, it is computationally expensive, hence
+ * the use of GPU is strongly recommended for faster performance as opposed to using CPU. Note that
+ * it is also common to stack convolution layers with different output channels for more
+ * representations of the input data.
  *
  * <p>Current implementations of {@code Convolution} are {@link Conv1D} with input dimension of
  * {@link LayoutType#WIDTH}, {@link Conv2D} with input dimension of {@link LayoutType#WIDTH} and
- * {@link LayoutType#HEIGHT}, and lastly {@link Conv3D} with input dimension of
- * {@link LayoutType#WIDTH}, {@link LayoutType#HEIGHT}, and {@link LayoutType#DEPTH}. These
- * implementations share the same core principal as a {@code Convolution} layer does, with the
- * difference being the number of input dimension each operates on as denoted by {@code ConvXD}
- * for {@code X} dimension(s).
+ * {@link LayoutType#HEIGHT}, and lastly {@link Conv3D} with input dimension of {@link
+ * LayoutType#WIDTH}, {@link LayoutType#HEIGHT}, and {@link LayoutType#DEPTH}. These implementations
+ * share the same core principal as a {@code Convolution} layer does, with the difference being the
+ * number of input dimension each operates on as denoted by {@code ConvXD} for {@code X}
+ * dimension(s).
  */
 public abstract class Convolution extends ParameterBlock {
 

--- a/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
@@ -31,36 +31,36 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * <p>In batch training (training with more than one samples per iteration), a batch
- * normalization layer works by normalizing the values of input data to have mean of 0 and
- * variance of 1. Since this may alter the representation of a layer, two parameters (\
- * (\gamma\) and \(\beta\)) are learned along the normalization process to respectively scale and
- * shift the normalized output (activations) to have any mean and variance so the network can
- * utilize non-linear transformations such as sigmoid function as described in the
- * <a href="https://arxiv.org/abs/1502.03167">paper</a>. During backpropagation, both \(\gamma\) and
+ * In batch training (training with more than one samples per iteration), a batch normalization
+ * layer works by normalizing the values of input data to have mean of 0 and variance of 1. Since
+ * this may alter the representation of a layer, two parameters (\ (\gamma\) and \(\beta\)) are
+ * learned along the normalization process to respectively scale and shift the normalized output
+ * (activations) to have any mean and variance so the network can utilize non-linear transformations
+ * such as sigmoid function as described in the <a
+ * href="https://arxiv.org/abs/1502.03167">paper</a>. During backpropagation, both \(\gamma\) and
  * \(\beta\) parameters are included following the chain-rule in derivation.
  *
  * <p>The problem of varying distribution of input data requires the training process of a deep
- * network to compensate for each different data distribution per batch, hence changing
- * parameters' values as new batch data is processed and changes distribution of the network's
- * (and each of its layers) activations. This condition is termed as internal covariate shift,
- * and such occurrence prevents the network to learn faster and generalize better to unseen data.
+ * network to compensate for each different data distribution per batch, hence changing parameters'
+ * values as new batch data is processed and changes distribution of the network's (and each of its
+ * layers) activations. This condition is termed as internal covariate shift, and such occurrence
+ * prevents the network to learn faster and generalize better to unseen data.
  *
  * <p>With batch normalization, one benefits by having faster learning process as batch
- * normalization allows larger learning rate without causing gradient problems on backpropagation
- * as all inputs are normalized and hence reducing the scale of weight update impact on
+ * normalization allows larger learning rate without causing gradient problems on backpropagation as
+ * all inputs are normalized and hence reducing the scale of weight update impact on
  * backpropagation. In some cases, the utilization of batch normalization layer regularizes the
- * network and reduces, even eliminates, the need for dropout, which in turn results in even
- * faster training process since dropout slows down training by 2-3 times. However, it was
- * reported that batch normalization may not be beneficial when small batch sizes are used.
+ * network and reduces, even eliminates, the need for dropout, which in turn results in even faster
+ * training process since dropout slows down training by 2-3 times. However, it was reported that
+ * batch normalization may not be beneficial when small batch sizes are used.
  *
- * <p>Formally, batch normalization is represented below:
- * <br>\(\hat{x} \:=\: \frac{x \:-\: \mu_{batch}}{\sqrt{\sigma^2_{batch} \:+\: \epsilon}}\),
- * <br>where \(\hat{x}\) is the normalized input, \(\mu_{batch}\) and \(\sigma^2_{batch}\)
- * respectively denote the mean and variance of a batch, and \(\epsilon\) (epsilon) is a constant
- * for numerical stability. The scale and shift operation can be formally defined as follows:
- * <br>\(y \:=\: \gamma\hat{x} \:+\: \beta\),
- * <br>where \(\gamma\) is the scale factor and \(\beta\) is the shift factor.
+ * <p>Formally, batch normalization is represented below: <br>
+ * \(\hat{x} \:=\: \frac{x \:-\: \mu_{batch}}{\sqrt{\sigma^2_{batch} \:+\: \epsilon}}\), <br>
+ * where \(\hat{x}\) is the normalized input, \(\mu_{batch}\) and \(\sigma^2_{batch}\) respectively
+ * denote the mean and variance of a batch, and \(\epsilon\) (epsilon) is a constant for numerical
+ * stability. The scale and shift operation can be formally defined as follows: <br>
+ * \(y \:=\: \gamma\hat{x} \:+\: \beta\), <br>
+ * where \(\gamma\) is the scale factor and \(\beta\) is the shift factor.
  */
 public class BatchNorm extends ParameterBlock {
 

--- a/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
@@ -31,10 +31,36 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Normalizes a data batch by mean and variance, and applies a scale gamma as well as offset beta.
+ * <p>In batch training (training with more than one samples per iteration), a batch
+ * normalization layer works by normalizing the values of input data to have mean of 0 and
+ * variance of 1. Since this may alter the representation of a layer, two parameters (\
+ * (\gamma\) and \(\beta\)) are learned along the normalization process to respectively scale and
+ * shift the normalized output (activations) to have any mean and variance so the network can
+ * utilize non-linear transformations such as sigmoid function as described in the
+ * <a href="https://arxiv.org/abs/1502.03167">paper</a>. During backpropagation, both \(\gamma\) and
+ * \(\beta\) parameters are included following the chain-rule in derivation.
  *
- * <p>See <a href="https://en.wikipedia.org/wiki/Batch_normalization">wikipedia</a> or the original
- * <a href="https://arxiv.org/abs/1502.03167">paper</a>.
+ * <p>The problem of varying distribution of input data requires the training process of a deep
+ * network to compensate for each different data distribution per batch, hence changing
+ * parameters' values as new batch data is processed and changes distribution of the network's
+ * (and each of its layers) activations. This condition is termed as internal covariate shift,
+ * and such occurrence prevents the network to learn faster and generalize better to unseen data.
+ *
+ * <p>With batch normalization, one benefits by having faster learning process as batch
+ * normalization allows larger learning rate without causing gradient problems on backpropagation
+ * as all inputs are normalized and hence reducing the scale of weight update impact on
+ * backpropagation. In some cases, the utilization of batch normalization layer regularizes the
+ * network and reduces, even eliminates, the need for dropout, which in turn results in even
+ * faster training process since dropout slows down training by 2-3 times. However, it was
+ * reported that batch normalization may not be beneficial when small batch sizes are used.
+ *
+ * <p>Formally, batch normalization is represented below:
+ * <br>\(\hat{x} \:=\: \frac{x \:-\: \mu_{batch}}{\sqrt{\sigma^2_{batch} \:+\: \epsilon}}\),
+ * <br>where \(\hat{x}\) is the normalized input, \(\mu_{batch}\) and \(\sigma^2_{batch}\)
+ * respectively denote the mean and variance of a batch, and \(\epsilon\) (epsilon) is a constant
+ * for numerical stability. The scale and shift operation can be formally defined as follows:
+ * <br>\(y \:=\: \gamma\hat{x} \:+\: \beta\),
+ * <br>where \(\gamma\) is the scale factor and \(\beta\) is the shift factor.
  */
 public class BatchNorm extends ParameterBlock {
 

--- a/api/src/main/java/ai/djl/nn/norm/Dropout.java
+++ b/api/src/main/java/ai/djl/nn/norm/Dropout.java
@@ -28,12 +28,30 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Applies dropout operation to an input array.
+ * <p>A dropout layer benefits a network by allowing some units (neurons), and hence their
+ * respective connections, of a network to be randomly and temporarily removed by setting its
+ * value to 0 <b>only</b> during training by specified probability \(p\), usually set to 0.5. The
+ * use of dropout acts as if multiple networks with different architectures had been trained, and
+ * during test/inference, the removed unit's output is multiplied by \(p\) as an approximation of
+ * the averaged output of all the possible network architectures for that unit. The implementation
+ * of dropout gives state-of-the-art performances for diverse tasks as shown in the proposal's
+ * <a href="https://www.cs.toronto.edu/~hinton/absps/JMLRdropout.pdf">paper</a>, suggesting its
+ * general-use capability.
  *
- * <p>During training, each element of the input is set to zero with probability p. The whole array
- * is rescaled by 1/(1−p) to keep the expected sum of the input unchanged. During testing, this
- * dropout does not change the input if mode is ‘training’. If mode is ‘always’, the same
- * computation as during training will be applied.
+ * <p>The idea of dropout itself was proposed in 2014, with the purpose of improving the
+ * performance of large networks due to co-adaptation, where some connections are stronger and
+ * learned more while other connections become weaker and loses their impact on the prediction,
+ * resulting in network overfitting. It was also created as an alternative for costly networks,
+ * such as large or ensemble networks, by removing several units, hence creating different
+ * thinned network architectures and simulates multiple networks within a single network, greatly
+ * reducing the computation cost.
+ *
+ * <p>Dropout is recommended to be used when one is trying to optimize an overfitting network or
+ * when large dataset is available. It is still quite commonly used in many publications due to
+ * its generalization capability. However, using dropout may not prevent overfitting due to
+ * variation and limited size of the dataset, and it is reported that dropout layer increases
+ * training time by 2-3 times since different simulated multiple networks are trained for each
+ * iteration, thus resulting in noisy parameter updates.
  */
 public class Dropout extends ParameterBlock {
 

--- a/api/src/main/java/ai/djl/nn/norm/Dropout.java
+++ b/api/src/main/java/ai/djl/nn/norm/Dropout.java
@@ -28,30 +28,30 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * <p>A dropout layer benefits a network by allowing some units (neurons), and hence their
- * respective connections, of a network to be randomly and temporarily removed by setting its
- * value to 0 <b>only</b> during training by specified probability \(p\), usually set to 0.5. The
- * use of dropout acts as if multiple networks with different architectures had been trained, and
- * during test/inference, the removed unit's output is multiplied by \(p\) as an approximation of
- * the averaged output of all the possible network architectures for that unit. The implementation
- * of dropout gives state-of-the-art performances for diverse tasks as shown in the proposal's
- * <a href="https://www.cs.toronto.edu/~hinton/absps/JMLRdropout.pdf">paper</a>, suggesting its
+ * A dropout layer benefits a network by allowing some units (neurons), and hence their respective
+ * connections, of a network to be randomly and temporarily removed by setting its value to 0
+ * <b>only</b> during training by specified probability \(p\), usually set to 0.5. The use of
+ * dropout acts as if multiple networks with different architectures had been trained, and during
+ * test/inference, the removed unit's output is multiplied by \(p\) as an approximation of the
+ * averaged output of all the possible network architectures for that unit. The implementation of
+ * dropout gives state-of-the-art performances for diverse tasks as shown in the proposal's <a
+ * href="https://www.cs.toronto.edu/~hinton/absps/JMLRdropout.pdf">paper</a>, suggesting its
  * general-use capability.
  *
- * <p>The idea of dropout itself was proposed in 2014, with the purpose of improving the
- * performance of large networks due to co-adaptation, where some connections are stronger and
- * learned more while other connections become weaker and loses their impact on the prediction,
- * resulting in network overfitting. It was also created as an alternative for costly networks,
- * such as large or ensemble networks, by removing several units, hence creating different
- * thinned network architectures and simulates multiple networks within a single network, greatly
- * reducing the computation cost.
+ * <p>The idea of dropout itself was proposed in 2014, with the purpose of improving the performance
+ * of large networks due to co-adaptation, where some connections are stronger and learned more
+ * while other connections become weaker and loses their impact on the prediction, resulting in
+ * network overfitting. It was also created as an alternative for costly networks, such as large or
+ * ensemble networks, by removing several units, hence creating different thinned network
+ * architectures and simulates multiple networks within a single network, greatly reducing the
+ * computation cost.
  *
  * <p>Dropout is recommended to be used when one is trying to optimize an overfitting network or
- * when large dataset is available. It is still quite commonly used in many publications due to
- * its generalization capability. However, using dropout may not prevent overfitting due to
- * variation and limited size of the dataset, and it is reported that dropout layer increases
- * training time by 2-3 times since different simulated multiple networks are trained for each
- * iteration, thus resulting in noisy parameter updates.
+ * when large dataset is available. It is still quite commonly used in many publications due to its
+ * generalization capability. However, using dropout may not prevent overfitting due to variation
+ * and limited size of the dataset, and it is reported that dropout layer increases training time by
+ * 2-3 times since different simulated multiple networks are trained for each iteration, thus
+ * resulting in noisy parameter updates.
  */
 public class Dropout extends ParameterBlock {
 


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/enQtODAwOTg0OTUzNDEwLTdlY2M4NmNlZTMzM2Q4MDUyZThkYzQwNmE2MDVhNTRiZDcxNTNlMWJhNTZkNWE1OGU2Nzg3MmY1OWQzN2Q5Mzk) to get in touch with development team, ask questions, find out what's cooking and more!

## Description ##
Fixes some of #44 and contains improved documentation on the following classes:
- [x] `Convolution`
- [x] `Conv1D`
- [x] `Conv2D`
- [x] `Conv3D`
- [x] `BatchNorm`
- [x] `Dropout`

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (see comments below)
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] `Convolution` - Added documentation on how convolution works, benefits and drawbacks, and paper references.
- [x] `Conv1D` - Specified how `Conv1D` differs from `Convolution` by its dimension size and common use cases.
- [x] `Conv2D` - Specified `Conv2D` specifications and common use cases.
- [x] `Conv3D` - Specified `Conv3D` specifications, how it differs from others, benefits/drawbacks, and common use cases.
- [x] `BatchNorm` - Explained the concept and formal definition of batch normalization, its proposal paper, and benefits/drawbacks.
- [x] `Dropout` - Explained the concept of dropout, its proposal paper, and benefits/drawbacks.

## Comments ##
- For `Conv1D`, `Conv2D`, and `Conv3D`, I was quite unsure of what else to include since these three share common operations as specified in `Convolution` class, so if anything is missing please let me know so the missing aspects can be obtained.
- `Dropout` has different papers, some suggesting that this [2014 paper](https://www.cs.toronto.edu/~hinton/absps/JMLRdropout.pdf) is the original proposal while others suggest the earlier [2012 paper](https://arxiv.org/abs/1207.0580) as the original proposal, despite the former having more citations. I need further confirmation on this.
