### PR TITLE
Some simple Unicode preprocessing

### DIFF
--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Unicode normalization does not take care of „exotic“ hyphens that we normally do not want in NLP
+ * Unicode normalization does not take care of "exotic“ hyphens that we normally do not want in NLP
  * input. This preprocessor turns all Hyphens into „normal“ ASCII minus-hyphen characters (U+002D).
  * Invisible soft hyphens are dropped from the input.
  */

--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at
@@ -19,8 +19,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Unicode normalization does not take care of "exotic“ hyphens that we normally do not want in NLP
- * input. This preprocessor turns all Hyphens into "normal“ ASCII minus-hyphen characters (U+002D).
+ * Unicode normalization does not take care of "exotic" hyphens that we normally do not want in NLP
+ * input. This preprocessor turns all Hyphens into "normal" ASCII minus-hyphen characters (U+002D).
  * Invisible soft hyphens are dropped from the input.
  */
 public class HyphenNormalizer implements TextProcessor {

--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
@@ -19,25 +19,27 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Unicode normalization does not take care of „exotic“ hyphens that we normally do not want in NLP input.
- * This preprocessor turns all Hyphens into „normal“ ASCII minus-hyphen characters (U+002D).
+ * Unicode normalization does not take care of „exotic“ hyphens that we normally do not want in NLP
+ * input. This preprocessor turns all Hyphens into „normal“ ASCII minus-hyphen characters (U+002D).
  * Invisible soft hyphens are dropped from the input.
  */
 public class HyphenNormalizer implements TextProcessor {
 
     private static final int SOFT_HYPHEN = 0x00AD;
 
-    private static final Set<Integer> HYPHENS = new HashSet<>(Arrays.asList(
-            0x002D, 0x007E, 0x00AD, 0x058A, 0x05BE, 0x2010, 0x2011, 0x2012, 0x2013, 0x2014, 0x2015, 0x2053, 0x207B,
-            0x208B, 0x2212, 0x2E3A, 0x2E3B, 0x301C, 0x3030, 0xFE31, 0xFE32, 0xFE58, 0xFE63, 0xFF0D
-    ));
+    private static final Set<Integer> HYPHENS =
+            new HashSet<>(
+                    Arrays.asList(
+                            0x002D, 0x007E, 0x00AD, 0x058A, 0x05BE, 0x2010, 0x2011, 0x2012, 0x2013,
+                            0x2014, 0x2015, 0x2053, 0x207B, 0x208B, 0x2212, 0x2E3A, 0x2E3B, 0x301C,
+                            0x3030, 0xFE31, 0xFE32, 0xFE58, 0xFE63, 0xFF0D));
 
     /**
-     * Returns whether the given code point is a hyphen-like codepoint.
-     * Tests for hyphen-minus, tilde, soft hyphen, armenian hyphen,
-     * hebrew punctuation maqaf, canadian syllabics hyphen, mongolian hyphen, non-breaking hyphen, figure dash,
-     * en dash, em dash, horizontal bar, swung dash, superscript minus, subscript minus, minus sign,
-     * double oblique hyphen, two-em dash, three-em dash, wave dash, wavy dash, katakana-hiragana double hyphen
+     * Returns whether the given code point is a hyphen-like codepoint. Tests for hyphen-minus,
+     * tilde, soft hyphen, armenian hyphen, hebrew punctuation maqaf, canadian syllabics hyphen,
+     * mongolian hyphen, non-breaking hyphen, figure dash, en dash, em dash, horizontal bar, swung
+     * dash, superscript minus, subscript minus, minus sign, double oblique hyphen, two-em dash,
+     * three-em dash, wave dash, wavy dash, katakana-hiragana double hyphen
      *
      * @param codePoint A unicode code point. (not a char!)
      * @return true: given code point represents a hyphen-like glyph
@@ -50,16 +52,17 @@ public class HyphenNormalizer implements TextProcessor {
      * Replaces hyphen like codepoints by ASCII "-", removes soft hyphens.
      *
      * @param s input string to replace hyphens in
-     * @return the same string with soft hyphens dropped and hyphen-like codepoints replaced by an ASCII minus.
+     * @return the same string with soft hyphens dropped and hyphen-like codepoints replaced by an
+     *     ASCII minus.
      */
     public static String normalizeHyphens(final String s) {
         final StringBuilder temp = new StringBuilder(s.length());
         int position = 0;
         while (position < s.length()) {
             final int cp = s.codePointAt(position);
-            if (cp == SOFT_HYPHEN) { //drop soft hyphens
-                //do nothing
-            } else if (isHyphenLike(cp)) {//replace "exotic" hyphens by a simple ASCII '-'
+            if (cp == SOFT_HYPHEN) { // drop soft hyphens
+                // do nothing
+            } else if (isHyphenLike(cp)) { // replace "exotic" hyphens by a simple ASCII '-'
                 temp.append('-');
             } else {
                 temp.appendCodePoint(cp);

--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 /**
  * Unicode normalization does not take care of "exotic“ hyphens that we normally do not want in NLP
- * input. This preprocessor turns all Hyphens into „normal“ ASCII minus-hyphen characters (U+002D).
+ * input. This preprocessor turns all Hyphens into "normal“ ASCII minus-hyphen characters (U+002D).
  * Invisible soft hyphens are dropped from the input.
  */
 public class HyphenNormalizer implements TextProcessor {

--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/HyphenNormalizer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.modality.nlp.preprocess;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Unicode normalization does not take care of „exotic“ hyphens that we normally do not want in NLP input.
+ * This preprocessor turns all Hyphens into „normal“ ASCII minus-hyphen characters (U+002D).
+ * Invisible soft hyphens are dropped from the input.
+ */
+public class HyphenNormalizer implements TextProcessor {
+
+    private static final int SOFT_HYPHEN = 0x00AD;
+
+    private static final Set<Integer> HYPHENS = new HashSet<>(Arrays.asList(
+            0x002D, 0x007E, 0x00AD, 0x058A, 0x05BE, 0x2010, 0x2011, 0x2012, 0x2013, 0x2014, 0x2015, 0x2053, 0x207B,
+            0x208B, 0x2212, 0x2E3A, 0x2E3B, 0x301C, 0x3030, 0xFE31, 0xFE32, 0xFE58, 0xFE63, 0xFF0D
+    ));
+
+    /**
+     * Returns whether the given code point is a hyphen-like codepoint.
+     * Tests for hyphen-minus, tilde, soft hyphen, armenian hyphen,
+     * hebrew punctuation maqaf, canadian syllabics hyphen, mongolian hyphen, non-breaking hyphen, figure dash,
+     * en dash, em dash, horizontal bar, swung dash, superscript minus, subscript minus, minus sign,
+     * double oblique hyphen, two-em dash, three-em dash, wave dash, wavy dash, katakana-hiragana double hyphen
+     *
+     * @param codePoint A unicode code point. (not a char!)
+     * @return true: given code point represents a hyphen-like glyph
+     */
+    public static boolean isHyphenLike(final Integer codePoint) {
+        return HYPHENS.contains(codePoint);
+    }
+
+    /**
+     * Replaces hyphen like codepoints by ASCII "-", removes soft hyphens.
+     *
+     * @param s input string to replace hyphens in
+     * @return the same string with soft hyphens dropped and hyphen-like codepoints replaced by an ASCII minus.
+     */
+    public static String normalizeHyphens(final String s) {
+        final StringBuilder temp = new StringBuilder(s.length());
+        int position = 0;
+        while (position < s.length()) {
+            final int cp = s.codePointAt(position);
+            if (cp == SOFT_HYPHEN) { //drop soft hyphens
+                //do nothing
+            } else if (isHyphenLike(cp)) {//replace "exotic" hyphens by a simple ASCII '-'
+                temp.append('-');
+            } else {
+                temp.appendCodePoint(cp);
+            }
+            position += Character.isBmpCodePoint(cp) ? 1 : 2;
+        }
+        return temp.toString();
+    }
+
+    @Override
+    public List<String> preprocess(final List<String> tokens) {
+        return tokens.stream().map(HyphenNormalizer::normalizeHyphens).collect(Collectors.toList());
+    }
+}

--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at

--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizer.java
@@ -17,9 +17,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Applies unicode normalization to input strings.
- * This is particularly important if you are dealing with non-English input or with text originating from OCR
- * applications.
+ * Applies unicode normalization to input strings. This is particularly important if you are dealing
+ * with non-English input or with text originating from OCR applications.
  */
 public class UnicodeNormalizer implements TextProcessor {
 
@@ -29,6 +28,7 @@ public class UnicodeNormalizer implements TextProcessor {
 
     /**
      * Unicode normalizer with a configurable normal form.
+     *
      * @param normalForm The normal form to use.
      */
     public UnicodeNormalizer(final Normalizer.Form normalForm) {
@@ -36,26 +36,28 @@ public class UnicodeNormalizer implements TextProcessor {
     }
 
     /**
-     * Default version of the Unicode Normalizer using NFKC normal form.
-     * If you do not know what normal form you need, this is the normal form you need.
+     * Default version of the Unicode Normalizer using NFKC normal form. If you do not know what
+     * normal form you need, this is the normal form you need.
      */
     public UnicodeNormalizer() {
         this(DEFAULT_FORM);
     }
 
     /**
-     * Normalizes a String using a sensible default normal form.
-     * Use this if you do not want to think about unicode preprocessing.
-     * @param  s Any non-null string
+     * Normalizes a String using a sensible default normal form. Use this if you do not want to
+     * think about unicode preprocessing.
+     *
+     * @param s Any non-null string
      * @return The given string with default unicode normalization applied.
      */
     public static String normalizeDefault(final String s) {
         return Normalizer.normalize(s, DEFAULT_FORM);
     }
 
-
     @Override
     public List<String> preprocess(final List<String> tokens) {
-        return tokens.stream().map((s) -> Normalizer.normalize(s, normalForm)).collect(Collectors.toList());
+        return tokens.stream()
+                .map((s) -> Normalizer.normalize(s, normalForm))
+                .collect(Collectors.toList());
     }
 }

--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.modality.nlp.preprocess;
+
+import java.text.Normalizer;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Applies unicode normalization to input strings.
+ * This is particularly important if you are dealing with non-English input or with text originating from OCR
+ * applications.
+ */
+public class UnicodeNormalizer implements TextProcessor {
+
+    public static final Normalizer.Form DEFAULT_FORM = Normalizer.Form.NFKC;
+
+    private final Normalizer.Form normalForm;
+
+    /**
+     * Unicode normalizer with a configurable normal form.
+     * @param normalForm The normal form to use.
+     */
+    public UnicodeNormalizer(final Normalizer.Form normalForm) {
+        this.normalForm = normalForm;
+    }
+
+    /**
+     * Default version of the Unicode Normalizer using NFKC normal form.
+     * If you do not know what normal form you need, this is the normal form you need.
+     */
+    public UnicodeNormalizer() {
+        this(DEFAULT_FORM);
+    }
+
+    /**
+     * Normalizes a String using a sensible default normal form.
+     * Use this if you do not want to think about unicode preprocessing.
+     * @param  s Any non-null string
+     * @return The given string with default unicode normalization applied.
+     */
+    public static String normalizeDefault(final String s) {
+        return Normalizer.normalize(s, DEFAULT_FORM);
+    }
+
+
+    @Override
+    public List<String> preprocess(final List<String> tokens) {
+        return tokens.stream().map((s) -> Normalizer.normalize(s, normalForm)).collect(Collectors.toList());
+    }
+}

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
@@ -12,17 +12,28 @@
  */
 package ai.djl.modality.nlp.preprocess;
 
+import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.List;
 
 public class HyphenNormalizerTest {
     @Test
     public void testHyphenNormalization() {
-        final String hyphens1 = "-\u002D\u007E\u058A\u05BE\u2010\u2011\u2012\u2013\u2014\u2015\u2053"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
-        final String softHyphen = " Uni\u00adcode "; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
-        final String hyphens2 = "\u207B\u208B\u2212\u2E3A\u2E3B\u301C\u3030\uFE31\uFE32\uFE58\uFE63\uFF0D"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
+        // Contrary to checkstyle rules, we really need unicode escapes here,
+        // otherwise the test will easily break if reformatted or depending
+        // on the behaviour of the editor using to edit this class.
+        // To get around checkstyle, we need a comment (any will do)  at the
+        // end of the line to supress the error after the string constants.
+        // These however break the build formatting check when run through the
+        // autoformatter if they are too long....
+        // Hence there is a dummy comment a the end of the literals to suppress
+        // checkstyle that is short enough to  make it through the autoformat
+        // unscathed. DO NOT REMOVE THOSE, OTHERWISE THE BUILD BREAKS!
+        final String hyphens1 =
+                "-\u002D\u007E\u058A\u05BE\u2010\u2011\u2012\u2013\u2014\u2015\u2053"; // supress
+        final String softHyphen = " Uni\u00adcode "; // supress
+        final String hyphens2 =
+                "\u207B\u208B\u2212\u2E3A\u2E3B\u301C\u3030\uFE31\uFE32\uFE58\uFE63\uFF0D"; // supress
         final String sentence = hyphens1 + softHyphen + hyphens2;
         final String expected = "------------ Unicode ------------";
         final SimpleTokenizer tokenizer = new SimpleTokenizer();

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.modality.nlp.preprocess;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class HyphenNormalizerTest {
+    @Test
+    public void testHyphenNormalization() {
+        final String hyphens1 = "-\u002D\u007E\u058A\u05BE\u2010\u2011\u2012\u2013\u2014\u2015\u2053"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
+        final String softHyphen = " Uni\u00adcode "; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
+        final String hyphens2 = "\u207B\u208B\u2212\u2E3A\u2E3B\u301C\u3030\uFE31\uFE32\uFE58\uFE63\uFF0D"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
+        final String sentence = hyphens1 + softHyphen + hyphens2;
+        final String expected = "------------ Unicode ------------";
+        final SimpleTokenizer tokenizer = new SimpleTokenizer();
+        final List<String> tokens = tokenizer.tokenize(sentence);
+        final HyphenNormalizer hyphenNormalizer = new HyphenNormalizer();
+        final List<String> processedTokens = hyphenNormalizer.preprocess(tokens);
+        Assert.assertEquals(tokenizer.buildSentence(processedTokens), expected);
+    }
+
+    public static void main(final String[] args) {
+        new HyphenNormalizerTest().testHyphenNormalization();
+    }
+}

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/HyphenNormalizerTest.java
@@ -16,24 +16,25 @@ import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+// We need to test specific unicode char changes - however some editors tend
+// to perform unicode normalization while saving, copy-pasting etc.
+// Hence this test would be broken accidentally if we were not using escaped unicode chars.
+// But in order for the build to pass, we need to suppress we need to suppress the checkstyle rule
+// here.
+@SuppressWarnings("AvoidEscapedUnicodeCharacters")
 public class HyphenNormalizerTest {
     @Test
     public void testHyphenNormalization() {
-        // Contrary to checkstyle rules, we really need unicode escapes here,
-        // otherwise the test will easily break if reformatted or depending
-        // on the behaviour of the editor using to edit this class.
-        // To get around checkstyle, we need a comment (any will do)  at the
-        // end of the line to supress the error after the string constants.
-        // These however break the build formatting check when run through the
-        // autoformatter if they are too long....
-        // Hence there is a dummy comment a the end of the literals to suppress
-        // checkstyle that is short enough to  make it through the autoformat
-        // unscathed. DO NOT REMOVE THOSE, OTHERWISE THE BUILD BREAKS!
+        // the following are a number of hyphen like glyphs from various languages
+        // and various special hyphens (like the half width hyphen)
         final String hyphens1 =
-                "-\u002D\u007E\u058A\u05BE\u2010\u2011\u2012\u2013\u2014\u2015\u2053"; // supress
-        final String softHyphen = " Uni\u00adcode "; // supress
+                "-\u002D\u007E\u058A\u05BE\u2010\u2011\u2012\u2013\u2014\u2015\u2053";
+        // the soft-hyphen is only meant to indicate were words can be split
+        // and should be removed in NLP applications
+        final String softHyphen = " Uni\u00adcode ";
+        // ...and more hyphens
         final String hyphens2 =
-                "\u207B\u208B\u2212\u2E3A\u2E3B\u301C\u3030\uFE31\uFE32\uFE58\uFE63\uFF0D"; // supress
+                "\u207B\u208B\u2212\u2E3A\u2E3B\u301C\u3030\uFE31\uFE32\uFE58\uFE63\uFF0D";
         final String sentence = hyphens1 + softHyphen + hyphens2;
         final String expected = "------------ Unicode ------------";
         final SimpleTokenizer tokenizer = new SimpleTokenizer();

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.modality.nlp.preprocess;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class UnicodeNormalizerTest {
+
+    @Test
+    public void testDefaultNormalization() {
+        final String sentence = "Unicode A\u0308A\uff21\uD835\uDC00\u00A01²₃\ufb01"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
+        final String expected = "Unicode \u00c4AAA 123fi"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
+        final SimpleTokenizer tokenizer = new SimpleTokenizer();
+        final List<String> tokens = tokenizer.tokenize(sentence);
+        final UnicodeNormalizer unicodeNormalizer = new UnicodeNormalizer();
+        final List<String> processedTokens = unicodeNormalizer.preprocess(tokens);
+        Assert.assertEquals(tokenizer.buildSentence(processedTokens), expected);
+    }
+
+}

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
@@ -16,22 +16,30 @@ import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+// We need to test specific unicode char changes - however some editors tend
+// to perform unicode normalization while saving, copy-pasting etc.
+// Hence this test would be broken accidentally if we were not using escaped unicode chars.
+// But in order for the build to pass, we need to suppress we need to suppress the checkstyle rule
+// here.
+@SuppressWarnings("AvoidEscapedUnicodeCharacters")
 public class UnicodeNormalizerTest {
 
     @Test
     public void testDefaultNormalization() {
-        // Contrary to checkstyle rules, we really need unicode escapes here,
-        // otherwise the test will easily break if reformatted or depending
-        // on the behaviour of the editor using to edit this class.
-        // To get around checkstyle, we need a comment (any will do)  at the
-        // end of the line to supress the error after the string constants.
-        // These however break the build formatting check when run through the
-        // autoformatter if they are too long....
-        // Hence there is a dummy comment a the end of the literals to suppress
-        // checkstyle that is short enough to  make it through the autoformat
-        // unscathed. DO NOT REMOVE THOSE, OTHERWISE THE BUILD BREAKS!
-        final String sentence = "Unicode A\u0308A\uff21\uD835\uDC00\u00A01²₃\ufb01"; // suppress
-        final String expected = "Unicode \u00c4AAA 123fi"; // suppress
+        // the following tests are contained in the test string below:
+        // - Umlaut Ä (with separate diaresis, two chars for one German letter,
+        // causes German dictionary lookups to fail)
+        // - "normal" A, should stay as is
+        // - full width capital latin A, occurs in mixed CJK/Latin
+        // text sources, should be turned into a normal A
+        // - Bold math letter A, not only used in math texts, but also
+        // often used in social media (e.g. twitter) to fake formatting,
+        // should be turned into a normal A as well
+        // - non breaking space, should be turned into a normal space
+        // - 1,2,3 in normal, super- and sub-script
+        // - an fi ligature, should be turned into f and i
+        final String sentence = "Unicode A\u0308A\uff21\uD835\uDC00\u00A01²₃\ufb01";
+        final String expected = "Unicode \u00c4AAA 123fi";
         final SimpleTokenizer tokenizer = new SimpleTokenizer();
         final List<String> tokens = tokenizer.tokenize(sentence);
         final UnicodeNormalizer unicodeNormalizer = new UnicodeNormalizer();

--- a/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
+++ b/api/src/test/java/ai/djl/modality/nlp/preprocess/UnicodeNormalizerTest.java
@@ -12,22 +12,30 @@
  */
 package ai.djl.modality.nlp.preprocess;
 
+import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.List;
 
 public class UnicodeNormalizerTest {
 
     @Test
     public void testDefaultNormalization() {
-        final String sentence = "Unicode A\u0308A\uff21\uD835\uDC00\u00A01²₃\ufb01"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
-        final String expected = "Unicode \u00c4AAA 123fi"; //contrary to checkstyle rules, we really need unicode escapes here, otherwise the test will easily break if reformatted
+        // Contrary to checkstyle rules, we really need unicode escapes here,
+        // otherwise the test will easily break if reformatted or depending
+        // on the behaviour of the editor using to edit this class.
+        // To get around checkstyle, we need a comment (any will do)  at the
+        // end of the line to supress the error after the string constants.
+        // These however break the build formatting check when run through the
+        // autoformatter if they are too long....
+        // Hence there is a dummy comment a the end of the literals to suppress
+        // checkstyle that is short enough to  make it through the autoformat
+        // unscathed. DO NOT REMOVE THOSE, OTHERWISE THE BUILD BREAKS!
+        final String sentence = "Unicode A\u0308A\uff21\uD835\uDC00\u00A01²₃\ufb01"; // suppress
+        final String expected = "Unicode \u00c4AAA 123fi"; // suppress
         final SimpleTokenizer tokenizer = new SimpleTokenizer();
         final List<String> tokens = tokenizer.tokenize(sentence);
         final UnicodeNormalizer unicodeNormalizer = new UnicodeNormalizer();
         final List<String> processedTokens = unicodeNormalizer.preprocess(tokens);
         Assert.assertEquals(tokenizer.buildSentence(processedTokens), expected);
     }
-
 }


### PR DESCRIPTION
## Description ##
This is PR contains two TextProcessors for NLP preprocessing. One does Unicode normalization which is necessary especially when working in non-English languages (e.g. German). The other implements functionality not done by normal unicode normalization and also normalizes hyphens. An exotic task, but necessary when e.g. processing HTML text or text that comes from an OCR engine.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x ] Changes are complete (i.e. I finished coding on this PR)
- [ x] All changes have test coverage:
- [ x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
- [ x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- new class UnicodeNormalizer, including docs & unit test
- new class HyphenationNormalizer, including docs & unit test

## Comments ##
N/A
