### PR TITLE
Fix toString formatting of nested Parallel/Sequential Block

### DIFF
--- a/api/src/main/java/ai/djl/nn/ParallelBlock.java
+++ b/api/src/main/java/ai/djl/nn/ParallelBlock.java
@@ -219,7 +219,8 @@ public class ParallelBlock extends AbstractBlock {
         StringBuilder sb = new StringBuilder(200);
         sb.append("Parallel(\n");
         for (Block block : blocks) {
-            sb.append('\t').append(block).append('\n');
+            String blockString = block.toString().replaceAll("(?m)^", "\t");
+            sb.append(blockString).append('\n');
         }
         sb.append(')');
         return sb.toString();

--- a/api/src/main/java/ai/djl/nn/SequentialBlock.java
+++ b/api/src/main/java/ai/djl/nn/SequentialBlock.java
@@ -201,7 +201,8 @@ public class SequentialBlock extends AbstractBlock {
         StringBuilder sb = new StringBuilder(200);
         sb.append("Sequential(\n");
         for (Block block : blocks) {
-            sb.append('\t').append(block).append('\n');
+            String blockString = block.toString().replaceAll("(?m)^", "\t");
+            sb.append(blockString).append('\n');
         }
         sb.append(')');
         return sb.toString();


### PR DESCRIPTION
## Description ##
So I found an issue with the string formatting of nested block structures when printing it to console. My laptop is not able to handle the load of some of the tests so I couldn't test the whole suite

Here's an example with Resnet18 block:
Left: new Right: old
![image](https://user-images.githubusercontent.com/5538666/81508202-624d3c00-9335-11ea-9bc2-fa3affa1d06d.png)


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Properly indent nested blocks