### PR TITLE
Fixed leak of native memory caused by closing pointers of ndarrays st…

### DIFF
--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -1534,8 +1534,7 @@ public class MxNDArray extends NativeResource implements LazyNDArray {
         }
         Pointer pointer = handle.getAndSet(null);
         if (pointer != null) {
-            // TODO: remove after fixing multi-thread data loading issue
-            // JnaUtils.waitToRead(pointer);
+            JnaUtils.waitToRead(pointer);
             JnaUtils.freeNdArray(pointer);
             manager.detach(getUid());
             manager = null;


### PR DESCRIPTION
…ill in use.

## Description ##
The mxnet engine performs operations asynchronously. Before freeing an NDArray it is necessary to wait for operations on the array to finish, otherwise we get continuous memory leaks and random crashes.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage: 
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Re-Added waiting for operations on NDArrays before closing

## Comments ##
There obviously was a reason this was commented out in the first place - is that reason fixed? But without this call, the engine simply crashes randomly, which probably is worse than what it was commented for.