### PR TITLE
Update LoggingTrainingListener.java

### DIFF
--- a/api/src/main/java/ai/djl/training/listener/LoggingTrainingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/LoggingTrainingListener.java
@@ -177,7 +177,7 @@ public class LoggingTrainingListener implements TrainingListener {
             logger.info(String.format("step P50: %.3f ms, P90: %.3f ms", p50, p90));
         }
 
-        if (metrics.hasMetric("step")) {
+        if (metrics.hasMetric("epoch")) {
             p50 = metrics.percentile("epoch", 50).getValue().longValue() / 1_000_000_000f;
             p90 = metrics.percentile("epoch", 90).getValue().longValue() / 1_000_000_000f;
             logger.info(String.format("epoch P50: %.3f s, P90: %.3f s", p50, p90));


### PR DESCRIPTION
Fixed incorrect metric name that may cause the following exception:
java.lang.IllegalArgumentException: Metric name not found: epoch

## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/enQtODAwOTg0OTUzNDEwLTdlY2M4NmNlZTMzM2Q4MDUyZThkYzQwNmE2MDVhNTRiZDcxNTNlMWJhNTZkNWE1OGU2Nzg3MmY1OWQzN2Q5Mzk) to get in touch with development team, ask questions, find out what's cooking and more!

## Description ##
When using LoggingTrainingListener, the following exception may occur:
java.lang.IllegalArgumentException: Metric name not found: epoch
as the check for the existence of the 'epoch' metric was incorrect.
This change should fix the issue.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change
