### PR TITLE
Added Example for Object Detection using Trained Tensorflow Models (SavedModel Format)

### DIFF
--- a/examples/docs/object_detection_with_tensorflow_saved_model.md
+++ b/examples/docs/object_detection_with_tensorflow_saved_model.md
@@ -1,0 +1,57 @@
+# Object detection using a model zoo model
+
+[Object detection](https://en.wikipedia.org/wiki/Object_detection) is a computer vision technique
+for locating instances of objects in images or videos.
+
+In this example we will use pre-trained model from [tensorflow model zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2_detection_zoo.md). 
+The following code has been tested with EfficientDet, SSD MobileNet V2, Faster RCNN Inception Resnet V2, but should work with all tensorflow object detection models.
+
+The source code can be found at [ObjectDetectionWithTensorflowSavedModel.java](../src/main/java/ai/djl/examples/inference/ObjectDetectionWithTensorflowSavedModel.java).
+
+## Setup guide
+
+To configure your development environment, follow [setup](../../docs/development/setup.md).
+
+## Run object detection example
+
+### Pretrained SSD Model
+ 
+Download and extract the ssd model from [here](http://download.tensorflow.org/models/object_detection/tf2/20200711/ssd_mobilenet_v2_320x320_coco17_tpu-8.tar.gz). You'll find a folder named ```saved_model```. This is the required model input for this example. 
+The parent folder is the repository folder the path of wchich you need to supply while running the example. 
+
+### Download Labelmap (optional)
+
+The ms-coco labelmap can be downloaded from [here](https://github.com/tensorflow/models/blob/master/research/object_detection/data/mscoco_label_map.pbtxt).
+DJL expects a synset. The synset can be generated from the labelmap pbtxt file using the utility class [TfLabelMap.java](../../tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfLabelMap.java).
+
+```java
+List<String> MS_COCO_CLASSES = TfLabelMap.toSynset(TfLabelMap.parse(Paths.get("label_map.pbtxt")));
+```
+
+### Input image file
+You can find the image used in this example in the project test resource folder: `src/test/resources/dog_bike_car.jpg`
+
+![dogs](../src/test/resources/dog_bike_car.jpg)
+
+### Build the project and run
+Use the following command to run the project:
+
+```
+cd examples
+./gradlew run -Dmain=ai.djl.examples.inference.ObjectDetectionWithTensorflowSavedModel -Dai.djl.repository.zoo.location=<path to your local model repository folder containing saved_model>
+```
+
+Your output should look like the following:
+
+```text
+[main] INFO ObjectDetectionWithTensorflowSavedModel - Detected objects image has been saved in: build\output\detected-dog_bike_car.png
+[main] INFO ObjectDetectionWithTensorflowSavedModel - [
+	class: "bicycle", probability: 0.80220, bounds: [x=0.147, y=0.209, width=0.576, height=0.603]
+	class: "car", probability: 0.73779, bounds: [x=0.596, y=0.145, width=0.297, height=0.149]
+	class: "dog", probability: 0.72259, bounds: [x=0.172, y=0.397, width=0.261, height=0.548]
+]
+```
+
+An output image with bounding box will be saved as build/output/detected-dog_bike_car.png:
+
+![detected-dogs](img/detected-tensorglow-model-dog_bike_car.png)

--- a/examples/src/main/java/ai/djl/examples/inference/ObjectDetectionWithTensorflowSavedModel.java
+++ b/examples/src/main/java/ai/djl/examples/inference/ObjectDetectionWithTensorflowSavedModel.java
@@ -1,0 +1,237 @@
+package ai.djl.examples.inference;/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license"file accompanying this file. This file is distributed on an "AS IS"BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import ai.djl.Application;
+import ai.djl.ModelException;
+import ai.djl.inference.Predictor;
+import ai.djl.modality.cv.Image;
+import ai.djl.modality.cv.ImageFactory;
+import ai.djl.modality.cv.output.BoundingBox;
+import ai.djl.modality.cv.output.DetectedObjects;
+import ai.djl.modality.cv.output.Rectangle;
+import ai.djl.modality.cv.translator.ImageClassificationTranslator;
+import ai.djl.modality.cv.translator.ObjectDetectionTranslator;
+import ai.djl.modality.cv.util.NDImageUtils;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.types.DataType;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ModelZoo;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.training.util.ProgressBar;
+import ai.djl.translate.Batchifier;
+import ai.djl.translate.TranslateException;
+import ai.djl.translate.TranslatorContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * An example of inference of object detection using saved model from TensorFlow 2 Detection Model Zoo.
+ *
+ * <p>Tested with EfficientDet, SSD MobileNet V2, Faster RCNN Inception Resnet V2 downloaded from <a
+ * href="https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2_detection_zoo.md">here</a>
+ *
+ * <p>See this <a
+ * href="https://github.com/awslabs/djl/blob/master/examples/docs/object_detection_with_tensorflow_saved_model.md">doc</a>
+ * for information about this example.
+ */
+public final class ObjectDetectionWithTensorflowSavedModel {
+
+    private static final Logger logger = LoggerFactory.getLogger(ObjectDetectionWithTensorflowSavedModel.class);
+    private static final List<String> MS_COCO_CLASSES = Arrays.asList("", "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train", "truck", "boat", "traffic light", "fire hydrant", "", "stop sign", "parking meter", "bench", "bird", "cat", "dog", "horse", "sheep", "cow", "elephant", "bear", "zebra", "giraffe", "", "backpack", "umbrella", "", "", "handbag", "tie", "suitcase", "frisbee", "skis", "snowboard", "sports ball", "kite", "baseball bat", "baseball glove", "skateboard", "surfboard", "tennis racket", "bottle", "", "wine glass", "cup", "fork", "knife", "spoon", "bowl", "banana", "apple", "sandwich", "orange", "broccoli", "carrot", "hot dog", "pizza", "donut", "cake", "chair", "couch", "potted plant", "bed", "", "dining table", "", "", "toilet", "", "tv", "laptop", "mouse", "remote", "keyboard", "cell phone", "microwave", "oven");
+
+    static {
+        if (System.getProperty("ai.djl.repository.zoo.location") == null)
+            System.setProperty("ai.djl.repository.zoo.location", "./models/");
+    }
+
+    private ObjectDetectionWithTensorflowSavedModel() {
+    }
+
+    public static void main(String[] args) throws IOException, ModelException, TranslateException {
+        DetectedObjects detection = ObjectDetectionWithTensorflowSavedModel.predict();
+        logger.info("{}", detection);
+    }
+
+    public static Criteria<Image, DetectedObjects> getTFSavedModelObjectDetectionCriteria() throws IOException {
+        return Criteria.builder()
+                .optApplication(Application.CV.OBJECT_DETECTION)
+                .setTypes(Image.class, DetectedObjects.class)
+                .optModelName("saved_model")//folder containing saved_model.pb in local repository
+                .optTranslator(
+                        TFSavedModelObjectDetectionTranslator
+                                .builder()
+                                .optSynset(MS_COCO_CLASSES)
+                                .build()
+                )
+                .optProgress(new ProgressBar())
+                .build();
+    }
+
+    public static DetectedObjects predict() throws IOException, ModelException, TranslateException {
+        Path imageFile = Paths.get("src/test/resources/dog_bike_car.jpg");
+        Image img = ImageFactory.getInstance().fromFile(imageFile);
+
+
+        try (ZooModel<Image, DetectedObjects> model = ModelZoo.loadModel(getTFSavedModelObjectDetectionCriteria())) {
+            try (Predictor<Image, DetectedObjects> predictor = model.newPredictor()) {
+
+                DetectedObjects detection = predictor.predict(img);
+                saveBoundingBoxImage(img, detection);
+                return detection;
+            }
+        }
+    }
+
+    private static void saveBoundingBoxImage(Image img, DetectedObjects detection) throws IOException {
+        Path outputDir = Paths.get("build/output");
+        Files.createDirectories(outputDir);
+
+        // Make image copy with alpha channel because original image was jpg
+        Image newImage = img.duplicate(Image.Type.TYPE_INT_ARGB);
+        newImage.drawBoundingBoxes(detection);
+
+        Path imagePath = outputDir.resolve("detected-dog_bike_car.png");
+        // OpenJDK can't save jpg with alpha channel
+        newImage.save(Files.newOutputStream(imagePath), "png");
+        logger.info("Detected objects image has been saved in: {}", imagePath);
+    }
+
+    private static final class TFSavedModelObjectDetectionTranslator extends ObjectDetectionTranslator {
+
+        /**
+         * Creates the {@link TFSavedModelObjectDetectionTranslator} from the given builder.
+         *
+         * @param builder the builder for the translator
+         */
+        protected TFSavedModelObjectDetectionTranslator(BaseBuilder<?> builder) {
+            super(builder);
+        }
+
+        @Override
+        public NDList processInput(TranslatorContext ctx, Image input) {
+            //input to tf object-detection models is a list of tensors, hence NDList
+            NDArray array = input.toNDArray(ctx.getNDManager(), Image.Flag.COLOR);
+            array = NDImageUtils.resize(array, 224)//optionally resize the image for faster processing
+                    .toType(DataType.UINT8, true);//tf object-detection models expect 8 bit unsigned integer tensor
+            array = array.expandDims(0);//tf object-detection models expect a 4 dimensional input
+            return new NDList(array);
+        }
+
+        @Override
+        public DetectedObjects processOutput(TranslatorContext ctx, NDList list) {
+            //output of tf object-detection models is a list of tensors, hence NDList in djl
+
+            //detected class ids are stored at index 5 of the NDList
+            List<String> classes = Arrays.stream(list.get(5).get(0).toArray())
+                    .map(c -> super.classes.get(c.intValue()))
+                    .collect(Collectors.toList());
+
+            //detected confidence scores are stored at index 1 of the NDList
+            List<Double> probs = Arrays.stream(list.get(1).get(0).toArray())
+                    .map(Number::doubleValue)
+                    .collect(Collectors.toList());
+
+            //detected bounding boxes are stored at index 7 of the NDList
+            List<BoundingBox> bboxes = IntStream.range(0, classes.size())
+                    .mapToObj(i -> list.get(7).get(0).get(i))
+                    .map(e -> new Rectangle(
+                            e.getFloat(1),
+                            e.getFloat(0),
+                            e.getFloat(3) - e.getFloat(1),
+                            e.getFloat(2) - e.getFloat(0)))
+                    .collect(Collectors.toList());
+
+            //filter out classes that has confidence score > 70%
+            List<Integer> indices = IntStream.range(0, probs.size())
+                    .filter(i -> probs.get(i) < 0.7)
+                    .boxed()
+                    .collect(Collectors.toList());
+            Collections.reverse(indices);
+            for (int index : indices) {
+                classes.remove(index);
+                probs.remove(index);
+                bboxes.remove(index);
+            }
+
+            return new DetectedObjects(classes, probs, bboxes);
+        }
+
+
+        @Override
+        public Batchifier getBatchifier() {
+            return null;
+        }
+
+        /**
+         * Creates a builder to build a {@code ImageClassificationTranslator}.
+         *
+         * @return a new builder
+         */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * A Builder to construct a {@code ImageClassificationTranslator}.
+         */
+        public static class Builder extends BaseBuilder<Builder> {
+
+            private boolean applySoftmax;
+
+            Builder() {
+            }
+
+            /**
+             * Sets whether to apply softmax when processing output. Some models already include softmax in the last
+             * layer, so don't apply softmax when processing model output.
+             *
+             * @param applySoftmax boolean whether to apply softmax
+             * @return the builder
+             */
+            public Builder optApplySoftmax(boolean applySoftmax) {
+                this.applySoftmax = applySoftmax;
+                return this;
+            }
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            protected Builder self() {
+                return this;
+            }
+
+            /**
+             * Builds the {@link ImageClassificationTranslator} with the provided data.
+             *
+             * @return an {@link ImageClassificationTranslator}
+             */
+            public TFSavedModelObjectDetectionTranslator build() {
+                addTransform(ndArray -> ndArray);//adding a dummy pipeline, execution fails without this
+                validate();
+                return new TFSavedModelObjectDetectionTranslator(this);
+            }
+        }
+    }
+}

--- a/examples/src/test/java/ai/djl/examples/inference/ObjectDetectionWithTensorflowSavedModelTest.java
+++ b/examples/src/test/java/ai/djl/examples/inference/ObjectDetectionWithTensorflowSavedModelTest.java
@@ -1,0 +1,37 @@
+package ai.djl.examples.inference;/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import ai.djl.ModelException;
+import ai.djl.modality.Classifications;
+import ai.djl.modality.cv.output.DetectedObjects;
+import ai.djl.translate.TranslateException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class ObjectDetectionWithTensorflowSavedModelTest {
+
+    @Test
+    public void testObjectDetection() throws ModelException, TranslateException, IOException {
+        DetectedObjects result = ObjectDetectionWithTensorflowSavedModel.predict();
+        Assert.assertEquals(result.getNumberOfObjects(), 3);
+        List<String> objects = Arrays.asList("dog", "bicycle", "car");
+        for (Classifications.Classification obj : result.items()) {
+            Assert.assertTrue(objects.contains(obj.getClassName()));
+            Assert.assertTrue(Double.compare(obj.getProbability(), 0.7) > 0);
+        }
+    }
+}

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfLabelMap.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfLabelMap.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.tensorflow.engine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class TfLabelMap {
+
+    public static Map<Integer, String> parse(Path pbtxtPath) throws IOException {
+        List<String> lines = Files.readAllLines(pbtxtPath);
+        List<String> items = new ArrayList<>();
+        items.add("");
+        lines.forEach(line -> {
+            if (line.contains("}")) {
+                String item = (items.get(0) + line.substring(0, line.indexOf("}") + 1)).replaceAll("( )+", " ");
+                item = item.substring(item.indexOf("{") + 1, item.indexOf("}")).trim();
+                items.set(0, item);
+                items.add(0, line.substring(line.indexOf("}") + 1));
+            } else {
+                items.set(0, items.get(0) + line);
+            }
+        });
+
+        Map<Integer, String> map = new TreeMap<>();
+
+        items.forEach(s -> {
+            Scanner scanner = new Scanner(s);
+            Integer id = null;
+            String name = null;
+            StringBuilder displayName = null;
+            while (scanner.hasNext()) {
+                String key = scanner.next().trim();
+                key = key.replaceAll(":", "");
+                switch (key) {
+                    case "id":
+                        id = scanner.nextInt();
+                        break;
+                    case "name":
+                        name = scanner.next().trim();
+                        break;
+                    case "display_name":
+                        displayName = new StringBuilder(scanner.next().trim());
+                        if (displayName.charAt(0) == '"') {
+                            while (displayName.charAt(displayName.length() - 1) != '"') {
+                                displayName.append(" ").append(scanner.next().trim());
+                            }
+                            displayName = new StringBuilder(displayName.substring(1, displayName.length() - 1));
+                        }
+                        break;
+                }
+            }
+            if (id != null)
+                map.put(id, displayName.toString());
+        });
+        return map;
+    }
+
+    public static List<String> toSynset(Map<Integer, String> map) {
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i <= Collections.max(map.keySet()); i++)
+            list.add(map.getOrDefault(i, ""));
+        return list;
+    }
+}
+
+
+
+


### PR DESCRIPTION
## Description ##
Added a simple example to use DJL to perform object detection using models trained in Tensorflow and exported to SavedModel format. The example includes a custom translator to correctly load models from the [TensorFlow 2 Detection Model Zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2_detection_zoo.md) 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For new examples, [README.md](https://github.com/uniquetrij/djl/blob/master/examples/docs/object_detection_with_tensorflow_saved_model.md) is added to explain what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change