### PR TITLE
Load config.properties from current folder by default

### DIFF
--- a/serving/src/main/java/ai/djl/serving/Arguments.java
+++ b/serving/src/main/java/ai/djl/serving/Arguments.java
@@ -12,6 +12,9 @@
  */
 package ai.djl.serving;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -74,8 +77,22 @@ public final class Arguments {
      *
      * @return the configuration file path
      */
-    public String getConfigFile() {
-        return configFile;
+    public Path getConfigFile() {
+        if (configFile == null) {
+            configFile = System.getProperty("ai.djl.conf", null);
+        }
+        if (configFile != null) {
+            Path file = Paths.get(configFile);
+            if (!Files.isRegularFile(file)) {
+                throw new IllegalArgumentException("Configuration file not found: " + configFile);
+            }
+            return file;
+        }
+        Path file = Paths.get("config.properties");
+        if (Files.isRegularFile(file)) {
+            return file;
+        }
+        return null;
     }
 
     /**

--- a/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
+++ b/serving/src/main/java/ai/djl/serving/util/ConfigManager.java
@@ -75,21 +75,14 @@ public final class ConfigManager {
     private ConfigManager(Arguments args) {
         prop = new Properties();
 
-        String filePath = args.getConfigFile();
-        if (filePath == null) {
-            filePath = System.getProperty("ai.djl.conf", null);
-        }
-        if (filePath != null && !filePath.isEmpty()) {
-            Path file = Paths.get(filePath);
-            if (Files.isRegularFile(file)) {
-                try (InputStream stream = Files.newInputStream(file)) {
-                    prop.load(stream);
-                } catch (IOException e) {
-                    throw new IllegalArgumentException("Unable to read configuration file", e);
-                }
-            } else {
-                throw new IllegalArgumentException("Configuration file not found: " + file);
+        Path file = args.getConfigFile();
+        if (file != null) {
+            try (InputStream stream = Files.newInputStream(file)) {
+                prop.load(stream);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Unable to read configuration file", e);
             }
+            prop.put("configFile", file.toString());
         }
 
         String modelStore = args.getModelStore();

--- a/serving/src/main/javadoc/overview.html
+++ b/serving/src/main/javadoc/overview.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+</head>
+<body>
+<p>This document is the API specification for the Deep Java Library (DJL) Serving.</p>
+
+<p>
+  The DJL serving module is a standalone web service that can serve models with REST API.
+  See <a href="https://github.com/awslabs/djl/tree/master/serving">here</a> for more details.
+</p>
+
+</body>
+</html>

--- a/tools/gradle/publish.gradle
+++ b/tools/gradle/publish.gradle
@@ -2,6 +2,7 @@ configure([
         project(':api'),
         project(':basicdataset'),
         project(':model-zoo'),
+        project(':serving'),
         project(':mxnet:mxnet-engine'),
         project(':mxnet:mxnet-model-zoo'),
         project(':pytorch:pytorch-engine'),


### PR DESCRIPTION
Change-Id: Ia748d6a0db8315d092691f33c3c570993b5b581a

## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Load config.properties by default from current working folder
- publish serving package to maven

