### PR TITLE
Adding Deconvolution support for MXNet engine. Throwing unsupported e…

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/internal/NDArrayEx.java
+++ b/api/src/main/java/ai/djl/ndarray/internal/NDArrayEx.java
@@ -277,6 +277,16 @@ public interface NDArrayEx {
             Shape dilation,
             int groups);
 
+    NDList deconvolution(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups);
+
     NDList linear(NDArray input, NDArray weight, NDArray bias);
 
     NDList embedding(

--- a/api/src/main/java/ai/djl/nn/convolutional/Conv1dTranspose.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv1dTranspose.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.nn.convolutional;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.types.LayoutType;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.nn.Block;
+import ai.djl.util.Preconditions;
+
+/**
+ * A {@code Conv1dTranspose} layer works similar to {@link Deconvolution} layer with the exception
+ * of the number of dimension it operates on being only one, which is {@link LayoutType#WIDTH}. The
+ * channel of the input data may be more than one, depending on what data is processed. Each filter
+ * slides through the data with only one direction of movement along the dimension itself.
+ *
+ * <p>The input to a {@code Conv1dTranspose} is an {@link ai.djl.ndarray.NDList} with a single 3-D
+ * {@link ai.djl.ndarray.NDArray}. The layout of the {@link ai.djl.ndarray.NDArray} must be "NCW".
+ * The shapes are
+ *
+ * <ul>
+ *   <li>{@code data: (batch_size, channel, width)}
+ *   <li>{@code weight: (num_filter, channel, kernel[0])}
+ *   <li>{@code bias: (num_filter,)}
+ *   <li>{@code out: (batch_size, num_filter, out_width)} <br>
+ *       {@code out_width = f(width, kernel[0], pad[0], oPad[0], stride[0], dilate[0])} <br>
+ *       {@code where f(x, k, p, oP, s, d) = (x-1)*s-2*p+k+oP}
+ * </ul>
+ *
+ * <p>Both {@code weight} and {@code bias} are learn-able parameters.
+ */
+public class Conv1dTranspose extends Deconvolution {
+
+    private static final LayoutType[] EXPECTED_LAYOUT = {
+        LayoutType.BATCH, LayoutType.CHANNEL, LayoutType.WIDTH
+    };
+
+    private static final String STRING_LAYOUT = "NCW";
+    private static final int NUM_DIMENSIONS = 3;
+
+    Conv1dTranspose(Builder builder) {
+        super(builder);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected LayoutType[] getExpectedLayout() {
+        return EXPECTED_LAYOUT;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getStringLayout() {
+        return STRING_LAYOUT;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected int numDimensions() {
+        return NUM_DIMENSIONS;
+    }
+
+    /**
+     * Applies 1D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, width)
+     * @return the output of the conv1dTranspose operation
+     */
+    public static NDList conv1dTranspose(NDArray input, NDArray weight) {
+        return conv1dTranspose(
+                input, weight, null, new Shape(1), new Shape(0), new Shape(0), new Shape(1));
+    }
+
+    /**
+     * Applies 1D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @return the output of the conv1dTranspose operation
+     */
+    public static NDList conv1dTranspose(NDArray input, NDArray weight, NDArray bias) {
+        return conv1dTranspose(
+                input, weight, bias, new Shape(1), new Shape(0), new Shape(0), new Shape(1));
+    }
+
+    /**
+     * Applies 1D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(width)
+     * @return the output of the conv1dTranspose operation
+     */
+    public static NDList conv1dTranspose(
+            NDArray input, NDArray weight, NDArray bias, Shape stride) {
+        return conv1dTranspose(
+                input, weight, bias, stride, new Shape(0), new Shape(0), new Shape(1));
+    }
+
+    /**
+     * Applies 1D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(width)
+     * @param padding implicit paddings on both sides of the input: Shape(width)
+     * @return the output of the conv1dTranspose operation
+     */
+    public static NDList conv1dTranspose(
+            NDArray input, NDArray weight, NDArray bias, Shape stride, Shape padding) {
+        return conv1dTranspose(input, weight, bias, stride, padding, new Shape(0), new Shape(1));
+    }
+
+    /**
+     * Applies 1D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(width)
+     * @param padding implicit paddings on both sides of the input: Shape(width)
+     * @param outPadding Controls the amount of implicit zero-paddings on both sides of the output
+     *     for outputPadding number of points for each dimension.
+     * @return the output of the conv1dTranspose operation
+     */
+    public static NDList conv1dTranspose(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding) {
+        return conv1dTranspose(input, weight, bias, stride, padding, outPadding, new Shape(1));
+    }
+
+    /**
+     * Applies 1D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(width)
+     * @param padding implicit paddings on both sides of the input: Shape(width)
+     * @param outPadding Controls the amount of implicit zero-paddings on both sides of the output
+     *     for outputPadding number of points for each dimension.
+     * @param dilation the spacing between kernel elements: Shape(width)
+     * @return the output of the conv1dTranspose operation
+     */
+    public static NDList conv1dTranspose(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation) {
+        return conv1dTranspose(input, weight, bias, stride, padding, outPadding, dilation, 1);
+    }
+
+    /**
+     * Applies 1D convolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(width)
+     * @param padding implicit paddings on both sides of the input: Shape(width)
+     * @param outPadding Controls the amount of implicit zero-paddings on both sides of the output
+     *     for outputPadding number of points for each dimension. Shape(width)
+     * @param dilation the spacing between kernel elements: Shape(width)
+     * @param groups split input into groups: input channel(input.size(1)) should be divisible by
+     *     the number of groups
+     * @return the output of the conv1dTranspose operation
+     */
+    public static NDList conv1dTranspose(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups) {
+        Preconditions.checkArgument(
+                input.getShape().dimension() == 3 && weight.getShape().dimension() == 3,
+                "the shape of input or weight doesn't match the conv1dTranspose");
+        Preconditions.checkArgument(
+                stride.dimension() == 1
+                        && padding.dimension() == 1
+                        && outPadding.dimension() == 1
+                        && dilation.dimension() == 1,
+                "the shape of stride or padding or dilation doesn't match the conv1dTranspose");
+        return Deconvolution.deconvolution(
+                input, weight, bias, stride, padding, outPadding, dilation, groups);
+    }
+
+    /**
+     * Creates a builder to build a {@code Conv1dTranspose}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** The Builder to construct a {@link Conv1dTranspose} type of {@link Block}. */
+    public static final class Builder extends DeconvolutionBuilder<Builder> {
+
+        /** Creates a builder that can build a {@link Conv1dTranspose} block. */
+        Builder() {
+            stride = new Shape(1);
+            padding = new Shape(0);
+            outPadding = new Shape(0);
+            dilation = new Shape(1);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /**
+         * Builds a {@link Conv1dTranspose} block.
+         *
+         * @return the {@link Conv1dTranspose} block
+         */
+        public Conv1dTranspose build() {
+            validate();
+            return new Conv1dTranspose(this);
+        }
+    }
+}

--- a/api/src/main/java/ai/djl/nn/convolutional/Conv2dTranspose.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Conv2dTranspose.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.nn.convolutional;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.types.LayoutType;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.nn.Block;
+import ai.djl.util.Preconditions;
+
+/**
+ * The input to a {@code Conv2dTranspose} is an {@link ai.djl.ndarray.NDList} with a single 4-D
+ * {@link ai.djl.ndarray.NDArray}. The layout of the {@link ai.djl.ndarray.NDArray} must be "NCHW".
+ * The shapes are
+ *
+ * <ul>
+ *   <li>{@code data: (batch_size, channel, height, width)}
+ *   <li>{@code weight: (num_filter, channel, kernel[0], kernel[1])}
+ *   <li>{@code bias: (num_filter,)}
+ *   <li>{@code out: (batch_size, num_filter, out_height, out_width)} <br>
+ *       {@code out_height = f(height, kernel[0], pad[0], oPad[0], stride[0], dilate[0])} <br>
+ *       {@code out_width = f(width, kernel[1], pad[1], oPad[1], stride[1], dilate[1])} <br>
+ *       {@code where f(x, k, p, oP, s, d) = (x-1)*s-2*p+k+oP}
+ * </ul>
+ *
+ * <p>Both {@code weight} and {@code bias} are learn-able parameters.
+ */
+public class Conv2dTranspose extends Deconvolution {
+
+    private static final LayoutType[] EXPECTED_LAYOUT = {
+        LayoutType.BATCH, LayoutType.CHANNEL, LayoutType.HEIGHT, LayoutType.WIDTH
+    };
+
+    private static final String STRING_LAYOUT = "NCHW";
+    private static final int NUM_DIMENSIONS = 4;
+
+    Conv2dTranspose(Builder builder) {
+        super(builder);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected LayoutType[] getExpectedLayout() {
+        return EXPECTED_LAYOUT;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getStringLayout() {
+        return STRING_LAYOUT;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected int numDimensions() {
+        return NUM_DIMENSIONS;
+    }
+
+    /**
+     * Applies 2D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, height, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, height,
+     *     width)
+     * @return the output of the conv2dTranspose operation
+     */
+    public static NDList conv2dTranspose(NDArray input, NDArray weight) {
+        return conv2dTranspose(
+                input,
+                weight,
+                null,
+                new Shape(1, 1),
+                new Shape(0, 0),
+                new Shape(0, 0),
+                new Shape(1, 1));
+    }
+
+    /**
+     * Applies 2D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, height, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, height,
+     *     width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @return the output of the conv2dTranspose operation
+     */
+    public static NDList conv2dTranspose(NDArray input, NDArray weight, NDArray bias) {
+        return conv2dTranspose(
+                input,
+                weight,
+                bias,
+                new Shape(1, 1),
+                new Shape(0, 0),
+                new Shape(0, 0),
+                new Shape(1, 1));
+    }
+
+    /**
+     * Applies 2D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, height, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, height,
+     *     width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(height, width)
+     * @return the output of the conv2dTranspose operation
+     */
+    public static NDList conv2dTranspose(
+            NDArray input, NDArray weight, NDArray bias, Shape stride) {
+        return conv2dTranspose(
+                input, weight, bias, stride, new Shape(0, 0), new Shape(0, 0), new Shape(1, 1));
+    }
+
+    /**
+     * Applies 2D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, height, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, height,
+     *     width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(height, width)
+     * @param padding implicit paddings on both sides of the input: Shape(height, width)
+     * @return the output of the conv2dTranspose operation
+     */
+    public static NDList conv2dTranspose(
+            NDArray input, NDArray weight, NDArray bias, Shape stride, Shape padding) {
+        return conv2dTranspose(
+                input, weight, bias, stride, padding, new Shape(0, 0), new Shape(1, 1));
+    }
+
+    /**
+     * Applies 2D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, height, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, height,
+     *     width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(height, width)
+     * @param padding implicit paddings on both sides of the input: Shape(height, width)
+     * @param outPadding Controls the amount of implicit zero-paddings on both sides of the output
+     *     for outputPadding number of points for each dimension.
+     * @return the output of the conv2dTranspose operation
+     */
+    public static NDList conv2dTranspose(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding) {
+        return conv2dTranspose(input, weight, bias, stride, padding, outPadding, new Shape(1, 1));
+    }
+
+    /**
+     * Applies 2D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, height, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, height,
+     *     width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(height, width)
+     * @param padding implicit paddings on both sides of the input: Shape(height, width)
+     * @param outPadding Controls the amount of implicit zero-paddings on both sides of the output
+     *     for outputPadding number of points for each dimension.
+     * @param dilation the spacing between kernel elements: Shape(height, width)
+     * @return the output of the conv2dTranspose operation
+     */
+    public static NDList conv2dTranspose(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation) {
+        return conv2dTranspose(input, weight, bias, stride, padding, outPadding, dilation, 1);
+    }
+
+    /**
+     * Applies 2D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, height, width)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, height,
+     *     width)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(height, width)
+     * @param padding implicit paddings on both sides of the input: Shape(height, width)
+     * @param outPadding Controls the amount of implicit zero-paddings on both sides of the output
+     *     for outputPadding number of points for each dimension. Shape(height, width)
+     * @param dilation the spacing between kernel elements: Shape(height, width)
+     * @param groups split input into groups: input channel(input.size(1)) should be divisible by
+     *     the number of groups
+     * @return the output of the conv2dTranspose operation
+     */
+    public static NDList conv2dTranspose(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups) {
+        Preconditions.checkArgument(
+                input.getShape().dimension() == 4 && weight.getShape().dimension() == 4,
+                "the shape of input or weight doesn't match the conv2dTranspose");
+        Preconditions.checkArgument(
+                stride.dimension() == 2
+                        && padding.dimension() == 2
+                        && outPadding.dimension() == 2
+                        && dilation.dimension() == 2,
+                "the shape of stride or padding or dilation doesn't match the conv2dTranspose");
+        return Deconvolution.deconvolution(
+                input, weight, bias, stride, padding, outPadding, dilation, groups);
+    }
+
+    /**
+     * Creates a builder to build a {@code Conv2dTranspose}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** The Builder to construct a {@link Conv2dTranspose} type of {@link Block}. */
+    public static final class Builder extends DeconvolutionBuilder<Builder> {
+
+        /** Creates a builder that can build a {@link Conv2dTranspose} block. */
+        Builder() {
+            stride = new Shape(1, 1);
+            padding = new Shape(0, 0);
+            outPadding = new Shape(0, 0);
+            dilation = new Shape(1, 1);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /**
+         * Builds a {@link Conv2dTranspose} block.
+         *
+         * @return the {@link Conv2dTranspose} block
+         */
+        public Conv2dTranspose build() {
+            validate();
+            return new Conv2dTranspose(this);
+        }
+    }
+}

--- a/api/src/main/java/ai/djl/nn/convolutional/Deconvolution.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Deconvolution.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.nn.convolutional;
+
+import ai.djl.Device;
+import ai.djl.MalformedModelException;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.LayoutType;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.nn.AbstractBlock;
+import ai.djl.nn.Block;
+import ai.djl.nn.Parameter;
+import ai.djl.nn.ParameterType;
+import ai.djl.training.ParameterStore;
+import ai.djl.util.PairList;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ * Transposed convolution, also named fractionally-strided convolution <a
+ * href="https://arxiv.org/pdf/1603.07285">Dumoulin &amp; Visin</a> or deconvolution <a
+ * href="https://ieeexplore.ieee.org/document/7298965">Long et al., 2015</a>, serves this purpose.
+ *
+ * <p>The need for transposed convolutions generally arises from the desire to use a transformation
+ * going in the opposite direction of a normal convolution, i.e., from something that has the shape
+ * of the output of some convolution to something that has the shape of its input while maintaining
+ * a connectivity pattern that is compatible with said convolution.
+ *
+ * <p>Current implementations of {@code Deconvolution} are {@link Conv1dTranspose} with input
+ * dimension of {@link LayoutType#WIDTH} and {@link Conv2dTranspose} with input dimension of {@link
+ * LayoutType#WIDTH} and {@link LayoutType#HEIGHT}. These implementations share the same core
+ * principal as a {@code Deconvolution} layer does, with the difference being the number of input
+ * dimension each operates on as denoted by {@code ConvXdTranspose} for {@code X} dimension(s).
+ */
+public abstract class Deconvolution extends AbstractBlock {
+
+    private static final byte VERSION = 1;
+
+    protected Shape kernelShape;
+    protected Shape stride;
+    protected Shape padding;
+    protected Shape outPadding;
+    protected Shape dilation;
+    protected int filters;
+    protected int groups;
+    protected boolean includeBias;
+
+    protected Parameter weight;
+    protected Parameter bias;
+
+    /**
+     * Creates a {@link Deconvolution} object.
+     *
+     * @param builder the {@code Builder} that has the necessary configurations
+     */
+    public Deconvolution(DeconvolutionBuilder<?> builder) {
+        super(VERSION);
+        kernelShape = builder.kernelShape;
+        stride = builder.stride;
+        padding = builder.padding;
+        outPadding = builder.outPadding;
+        dilation = builder.dilation;
+        filters = builder.filters;
+        groups = builder.groups;
+        includeBias = builder.includeBias;
+
+        weight =
+                addParameter(
+                        new Parameter("weight", this, ParameterType.WEIGHT),
+                        (inputShapes) ->
+                                new Shape(filters, inputShapes[0].get(1)).addAll(kernelShape));
+        if (includeBias) {
+            bias =
+                    addParameter(
+                            new Parameter("bias", this, ParameterType.BIAS), new Shape(filters));
+        }
+    }
+
+    /**
+     * Returns the expected layout of the input.
+     *
+     * @return the expected layout of the input
+     */
+    protected abstract LayoutType[] getExpectedLayout();
+
+    /**
+     * Returns the string representing the layout of the input.
+     *
+     * @return the string representing the layout of the input
+     */
+    protected abstract String getStringLayout();
+
+    /**
+     * Returns the number of dimensions of the input.
+     *
+     * @return the number of dimensions of the input
+     */
+    protected abstract int numDimensions();
+
+    /** {@inheritDoc} */
+    @Override
+    public NDList forward(
+            ParameterStore parameterStore,
+            NDList inputs,
+            boolean training,
+            PairList<String, Object> params) {
+        NDArray input = inputs.singletonOrThrow();
+        Device device = input.getDevice();
+        NDArray weightArr = parameterStore.getValue(weight, device, training);
+        NDArray biasArr = parameterStore.getValue(bias, device, training);
+        return deconvolution(
+                input, weightArr, biasArr, stride, padding, outPadding, dilation, groups);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void beforeInitialize(Shape[] inputs) {
+        this.inputShapes = inputs;
+        Shape inputShape = inputs[0];
+        Block.validateLayout(getExpectedLayout(), inputShape.getLayout());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Shape[] getOutputShapes(NDManager manager, Shape[] inputs) {
+        long[] shape = new long[numDimensions()];
+        shape[0] = inputs[0].get(0);
+        shape[1] = filters;
+        for (int i = 0; i < numDimensions() - 2; i++) {
+            shape[2 + i] =
+                    (inputs[0].get(2 + i) - 1) * stride.get(0)
+                            - 2 * padding.get(0)
+                            + kernelShape.get(i)
+                            + outPadding.get(i);
+        }
+        return new Shape[] {new Shape(shape)};
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void loadMetadata(byte version, DataInputStream is)
+            throws IOException, MalformedModelException {
+        if (version == VERSION) {
+            readInputShapes(is);
+        } else {
+            throw new MalformedModelException("Unsupported encoding version: " + version);
+        }
+    }
+
+    /**
+     * Applies N-D deconvolution over an input signal composed of several input planes.
+     *
+     * @param input the input {@code NDArray} of shape (batchSize, inputChannel, ...)
+     * @param weight filters {@code NDArray} of shape (outChannel, inputChannel/groups, ...)
+     * @param bias bias {@code NDArray} of shape (outChannel)
+     * @param stride the stride of the deconvolving kernel: Shape(w) or Shape(h, w)
+     * @param padding implicit paddings on both sides of the input: Shape(w) or Shape(h, w)
+     * @param outPadding Controls the amount of implicit zero-paddings on both sides of the output
+     *     for output_padding number of points for each dimension. Shape(w) or Shape(h, w)
+     * @param dilation the spacing between kernel elements: Shape(w) or Shape(h, w)
+     * @param groups split input into groups: input channel(input.size(1)) should be divisible by
+     *     the number of groups
+     * @return the output of the deconvolution operation
+     */
+    static NDList deconvolution(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups) {
+        return input.getNDArrayInternal()
+                .deconvolution(input, weight, bias, stride, padding, outPadding, dilation, groups);
+    }
+    /**
+     * A builder that can build any {@code Deconvolution} block.
+     *
+     * @param <T> the type of {@code Deconvolution} block to build
+     */
+    @SuppressWarnings("rawtypes")
+    public abstract static class DeconvolutionBuilder<T extends DeconvolutionBuilder> {
+
+        protected Shape kernelShape;
+        protected Shape stride;
+        protected Shape padding;
+        protected Shape outPadding;
+        protected Shape dilation;
+        protected int filters;
+        protected int groups = 1;
+        protected boolean includeBias = true;
+
+        /**
+         * Sets the shape of the kernel.
+         *
+         * @param kernelShape the shape of the kernel
+         * @return this Builder
+         */
+        public T setKernelShape(Shape kernelShape) {
+            this.kernelShape = kernelShape;
+            return self();
+        }
+
+        /**
+         * Sets the stride of the deconvolution. Defaults to 1 in each dimension.
+         *
+         * @param stride the shape of the stride
+         * @return this Builder
+         */
+        public T optStride(Shape stride) {
+            this.stride = stride;
+            return self();
+        }
+
+        /**
+         * Sets the padding along each dimension. Defaults to 0 along each dimension.
+         *
+         * @param padding the shape of padding along each dimension
+         * @return this Builder
+         */
+        public T optPadding(Shape padding) {
+            this.padding = padding;
+            return self();
+        }
+        /**
+         * Sets the out_padding along each dimension. Defaults to 0 along each dimension.
+         *
+         * @param outPadding the shape of out_padding along each dimension
+         * @return this Builder
+         */
+        public T optOutPadding(Shape outPadding) {
+            this.outPadding = outPadding;
+            return self();
+        }
+        /**
+         * Sets the dilation along each dimension. Defaults to 1 along each dimension.
+         *
+         * @param dilate the shape of dilation along each dimension
+         * @return this Builder
+         */
+        public T optDilation(Shape dilate) {
+            this.dilation = dilate;
+            return self();
+        }
+
+        /**
+         * Sets the <b>Required</b> number of filters.
+         *
+         * @param filters the number of deconvolution filters(channels)
+         * @return this Builder
+         */
+        public T setFilters(int filters) {
+            this.filters = filters;
+            return self();
+        }
+
+        /**
+         * Sets the number of group partitions.
+         *
+         * @param groups the number of group partitions
+         * @return this Builder
+         */
+        public T optGroups(int groups) {
+            this.groups = groups;
+            return self();
+        }
+
+        /**
+         * Sets the optional parameter of whether to include a bias vector. Includes bias by
+         * default.
+         *
+         * @param includeBias whether to use a bias vector parameter
+         * @return this Builder
+         */
+        public T optBias(boolean includeBias) {
+            this.includeBias = includeBias;
+            return self();
+        }
+
+        /**
+         * Validates that the required arguments are set.
+         *
+         * @throws IllegalArgumentException if the required arguments are not set
+         */
+        protected void validate() {
+            if (kernelShape == null || filters == 0) {
+                throw new IllegalArgumentException("Kernel and numFilters must be set");
+            }
+        }
+
+        protected abstract T self();
+    }
+}

--- a/api/src/main/java/ai/djl/nn/convolutional/package-info.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/package-info.java
@@ -13,6 +13,6 @@
 
 /**
  * Contains classes that define convolutional operations extending {@link
- * ai.djl.nn.convolutional.Convolution}.
+ * ai.djl.nn.convolutional.Convolution} and {@link ai.djl.nn.convolutional.Deconvolution}.
  */
 package ai.djl.nn.convolutional;

--- a/api/src/test/java/ai/djl/test/mock/MockNDArrayEx.java
+++ b/api/src/test/java/ai/djl/test/mock/MockNDArrayEx.java
@@ -297,6 +297,20 @@ public class MockNDArrayEx implements NDArrayEx {
 
     /** {@inheritDoc} */
     @Override
+    public NDList deconvolution(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups) {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDList linear(NDArray input, NDArray weight, NDArray bias) {
         return null;
     }

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -557,6 +557,37 @@ class MxNDArrayEx implements NDArrayEx {
 
     /** {@inheritDoc} */
     @Override
+    public NDList deconvolution(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups) {
+        MxOpParams params = new MxOpParams();
+        params.addParam("kernel", weight.getShape().slice(2));
+        params.addParam("stride", stride);
+        params.addParam("pad", padding);
+        params.addParam("adj", outPadding);
+        params.addParam("dilate", dilation);
+        params.addParam("num_group", groups);
+        params.addParam("num_filter", weight.getShape().get(0));
+
+        NDList inputs = new NDList(input, weight);
+        if (bias != null) {
+            params.add("no_bias", false);
+            inputs.add(bias);
+        } else {
+            params.add("no_bias", true);
+        }
+
+        return getManager().invoke("_npx_deconvolution", inputs, params);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDList linear(NDArray input, NDArray weight, NDArray bias) {
         MxOpParams params = new MxOpParams();
         params.addParam("num_hidden", weight.size(0));

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayEx.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayEx.java
@@ -367,6 +367,20 @@ public class PtNDArrayEx implements NDArrayEx {
 
     /** {@inheritDoc} */
     @Override
+    public NDList deconvolution(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDList linear(NDArray input, NDArray weight, NDArray bias) {
         return new NDList(JniUtils.linear((PtNDArray) input, (PtNDArray) weight, (PtNDArray) bias));
     }

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayEx.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayEx.java
@@ -342,6 +342,20 @@ public class TfNDArrayEx implements NDArrayEx {
 
     /** {@inheritDoc} */
     @Override
+    public NDList deconvolution(
+            NDArray input,
+            NDArray weight,
+            NDArray bias,
+            Shape stride,
+            Shape padding,
+            Shape outPadding,
+            Shape dilation,
+            int groups) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDList linear(NDArray input, NDArray weight, NDArray bias) {
         throw new UnsupportedOperationException("Not implemented");
     }


### PR DESCRIPTION
…rror for others.

## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!

## Description ##
This PR adds a Deconvolution abstract class and extensions for Conv1dTranspose and Conv2dTranspose to ai.djl.nn.convolutional. NDArrayEX is revised to include a deconvolution method and the MXNet implementation MXNDArrayEX is updated with bindings to the C Libraries. Unsupported Exceptions are thrown for other engines.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] MXNDArrayEX, tests, (and when applicable, Java doc)
- [x] PtNDArrayEX, tests, (and when applicable, Java doc)
- [x] TfNDArrayEX, tests, (and when applicable, Java doc)
- [x] NDArrayEX, tests, (and when applicable, Java doc)
- [x] BlockCoreTest, tests, (and when applicable, Java doc)
- [x] MockNDArrayEX, tests, (and when applicable, Java doc)

## Comments ##
- Adding transpose convolution blocks allows convolutional autoencoders and generative adversarial networks to be built in DJL.