### PR TITLE
Return null device if requesting gpu but non available on system

### DIFF
--- a/api/src/main/java/ai/djl/Device.java
+++ b/api/src/main/java/ai/djl/Device.java
@@ -53,11 +53,14 @@ public final class Device {
      *
      * @param deviceType the device type, typically CPU or GPU
      * @param deviceId the deviceId on the hardware.
-     * @return a {@code Device} instance
+     * @return a {@code Device} instance, null if not available
      */
     public static Device of(String deviceType, int deviceId) {
         if (Type.CPU.equals(deviceType)) {
             return CPU;
+        }
+        if (Type.GPU.equals(deviceType) && getGpuCount() == 0) {
+            return null;
         }
         String key = deviceType + '-' + deviceId;
         return CACHE.computeIfAbsent(key, k -> new Device(deviceType, deviceId));

--- a/api/src/main/java/ai/djl/Device.java
+++ b/api/src/main/java/ai/djl/Device.java
@@ -60,7 +60,9 @@ public final class Device {
             return CPU;
         }
         if (Type.GPU.equals(deviceType)) {
-            if (getGpuCount() == 0) return null;
+            if (getGpuCount() == 0) {
+                return null;
+            }
             try {
                 CudaUtils.getComputeCapability(deviceId);
             } catch (Exception e) {

--- a/api/src/main/java/ai/djl/Device.java
+++ b/api/src/main/java/ai/djl/Device.java
@@ -59,8 +59,13 @@ public final class Device {
         if (Type.CPU.equals(deviceType)) {
             return CPU;
         }
-        if (Type.GPU.equals(deviceType) && getGpuCount() == 0) {
-            return null;
+        if (Type.GPU.equals(deviceType)) {
+            if (getGpuCount() == 0) return null;
+            try {
+                CudaUtils.getComputeCapability(deviceId);
+            } catch (Exception e) {
+                return null;
+            }
         }
         String key = deviceType + '-' + deviceId;
         return CACHE.computeIfAbsent(key, k -> new Device(deviceType, deviceId));

--- a/api/src/test/java/ai/djl/DeviceTest.java
+++ b/api/src/test/java/ai/djl/DeviceTest.java
@@ -21,15 +21,24 @@ public class DeviceTest {
     @Test
     public void testDevice() {
         Assert.assertEquals(Device.cpu(), Device.of("cpu", -1));
+
         if (Device.getGpuCount() > 0) {
             Assert.assertEquals(Device.gpu(), Device.defaultDevice());
+            Assert.assertEquals(Device.gpu(), Device.of("gpu", 0));
         } else {
             Assert.assertEquals(Device.cpu(), Device.defaultDevice());
+            Assert.assertNull(Device.gpu());
         }
-        Assert.assertEquals(Device.gpu(), Device.of("gpu", 0));
-        Assert.assertEquals(Device.gpu(3), Device.of("gpu", 3));
+
+        if (Device.getGpuCount() > 2) {
+            Assert.assertEquals(Device.gpu(3), Device.of("gpu", 3));
+        } else {
+            Assert.assertNull(Device.gpu(3));
+        }
+
         Assert.assertNotEquals(Device.cpu(), Device.gpu());
         Device dev = Device.of("myDevice", 1);
+        Assert.assertNotNull(dev);
         Assert.assertEquals(dev.getDeviceType(), "myDevice");
     }
 }

--- a/api/src/test/java/ai/djl/util/cuda/CudaUtilsTest.java
+++ b/api/src/test/java/ai/djl/util/cuda/CudaUtilsTest.java
@@ -31,7 +31,7 @@ public class CudaUtilsTest {
             return;
         }
         // Possible to have CUDA and not have a GPU.
-        if (CudaUtils.getGpuCount() == 0) {
+        if (Device.getGpuCount() == 0) {
             return;
         }
 


### PR DESCRIPTION
## Description ##
Intuitively I thought that `Device.gpu()` would either throw an exception or return null in the case of no gpu on the system, apparently not. Here is a small patch to fix that. It also makes cases like `Device.defaultIfNull(Device.gpu())` work (Although we do have `Device.defaultDevice()` for that

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] `Device.of()` returns null if requesting gpu but none are available on the system
