### PR TITLE
Add CUDA_PATH env variable to windows cuda loader

### DIFF
--- a/api/src/main/java/ai/djl/util/cuda/CudaUtils.java
+++ b/api/src/main/java/ai/djl/util/cuda/CudaUtils.java
@@ -158,7 +158,13 @@ public final class CudaUtils {
                     return null;
                 }
                 Pattern p = Pattern.compile("cudart64_\\d+\\.dll");
-                String[] searchPath = path.split(";");
+                String cudaPath = System.getenv("CUDA_PATH");
+                String[] searchPath;
+                if (cudaPath == null) {
+                    searchPath = path.split(";");
+                } else {
+                    searchPath = (cudaPath + "\\bin\\;" + path).split(";");
+                }
                 for (String item : searchPath) {
                     File dir = new File(item);
                     File[] files = dir.listFiles(n -> p.matcher(n.getName()).matches());


### PR DESCRIPTION
## Description ##
On windows the env variable `CUDA_PATH` is always set by the cuda installer. I think the better default behavior is to search that path first before looking into other paths. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added CUDA_PATH to `CudaUtils.loadLibrary()` search