### PR TITLE
Fix issue #201, set limit to MAX_VALUE for SubDataset

### DIFF
--- a/api/src/main/java/ai/djl/training/dataset/RandomAccessDataset.java
+++ b/api/src/main/java/ai/djl/training/dataset/RandomAccessDataset.java
@@ -408,6 +408,7 @@ public abstract class RandomAccessDataset implements Dataset {
             this.indices = indices;
             this.from = from;
             this.to = to;
+            limit = Long.MAX_VALUE;
         }
 
         /** {@inheritDoc} */

--- a/basicdataset/src/test/java/ai/djl/basicdataset/ImageFolderTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/ImageFolderTest.java
@@ -26,6 +26,7 @@ import ai.djl.training.DefaultTrainingConfig;
 import ai.djl.training.Trainer;
 import ai.djl.training.TrainingConfig;
 import ai.djl.training.dataset.Batch;
+import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.loss.Loss;
 import ai.djl.translate.Pipeline;
 import ai.djl.translate.TranslateException;
@@ -106,5 +107,14 @@ public class ImageFolderTest {
                 pikachuBatch.close();
             }
         }
+    }
+
+    @Test
+    public void testRandomSplit() throws IOException, TranslateException {
+        Repository repository = Repository.newInstance("test", "src/test/resources/imagefolder");
+        ImageFolder dataset =
+                ImageFolder.builder().setRepository(repository).setSampling(1, false).build();
+        RandomAccessDataset[] sets = dataset.randomSplit(75, 25);
+        Assert.assertEquals(sets[0].size(), 2);
     }
 }


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
