### PR TITLE
rollback mkdocs-material version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: install Python Dependencies
-        run: pip3 install nbconvert mkdocs mkdocs-exclude mknotebooks mkdocs-material jupyter Pygments
+        run: pip3 install nbconvert mkdocs mkdocs-exclude mknotebooks mkdocs-material==6.0.1 jupyter Pygments
       - name: Install IJava kernel
         run: |
           git clone https://github.com/frankfliu/IJava.git

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,8 +31,7 @@ extra:
       link: https://zhuanlan.zhihu.com/c_1255493231133417472
 docs_dir: '../'
 plugins:
-  - search:
-      prebuild_index: true
+  - search
   - mknotebooks
   - exclude:
       regex:


### PR DESCRIPTION
## Description ##

mkdocs search feature failed due to the upgrade on versions. Just roll back to a previous one to avoid this issue

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change
