### PR TITLE
rollback mknotebooks version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: install Python Dependencies
-        run: pip3 install nbconvert mkdocs mkdocs-exclude mknotebooks mkdocs-material jupyter Pygments
+        run: pip3 install nbconvert==5.6.1 mkdocs mkdocs-exclude mknotebooks==0.4.1 mkdocs-material jupyter Pygments Markdown==3.2.2
       - name: Install IJava kernel
         run: |
           git clone https://github.com/frankfliu/IJava.git

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,8 +31,7 @@ extra:
       link: https://zhuanlan.zhihu.com/c_1255493231133417472
 docs_dir: '../'
 plugins:
-  - search:
-      prebuild_index: true
+  - search
   - mknotebooks
   - exclude:
       regex:


### PR DESCRIPTION
## Description ##
Current mknotebooks build is broken, just fix the version for now until we managed to fix this: https://github.com/greenape/mknotebooks/issues/90


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

