### PR TITLE
Suppress UnsupportedOperationException stacktrace in integration test

### DIFF
--- a/integration/src/main/java/ai/djl/integration/IntegrationTest.java
+++ b/integration/src/main/java/ai/djl/integration/IntegrationTest.java
@@ -359,7 +359,7 @@ public class IntegrationTest {
                     result = TestResult.SKIPPED;
                 } else if (e.getCause() instanceof UnsupportedOperationException) {
                     logger.info("Test {}.{} UNSUPPORTED", getName(), method.getName());
-                    logger.debug("", e.getCause());
+                    logger.trace("", e.getCause());
                     result = TestResult.UNSUPPORTED;
                 } else {
                     logger.error("Test {}.{} FAILED", getName(), method.getName());


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
