### PR TITLE
Workaround #179, allow load shared library from different ClassLoader

### DIFF
--- a/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/LibUtilsTest.java
+++ b/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/LibUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.pytorch.integration;
+
+import ai.djl.engine.Engine;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class LibUtilsTest {
+
+    @BeforeClass
+    public void setup() {
+        System.setProperty(
+                "ai.djl.pytorch.native_helper", "ai.djl.pytorch.integration.LibUtilsTest");
+    }
+
+    @AfterClass
+    public void teardown() {
+        System.setProperty("ai.djl.pytorch.native_helper", "");
+    }
+
+    @Test
+    public void test() {
+        Engine.getInstance();
+    }
+
+    public static void load(String path) {
+        System.load(path); // NOPMD
+    }
+}

--- a/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/MkldnnTest.java
+++ b/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/MkldnnTest.java
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-package integration;
+package ai.djl.pytorch.integration;
 
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;

--- a/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/ProfilerTest.java
+++ b/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/ProfilerTest.java
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-package integration;
+package ai.djl.pytorch.integration;
 
 import ai.djl.Application;
 import ai.djl.MalformedModelException;

--- a/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/package-info.java
+++ b/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+/** The integration test for testing PyTorch specific features. */
+package ai.djl.pytorch.integration;

--- a/pytorch/pytorch-native/src/main/java/ai/djl/pytorch/jni/NativeHelper.java
+++ b/pytorch/pytorch-native/src/main/java/ai/djl/pytorch/jni/NativeHelper.java
@@ -10,5 +10,19 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-/** The integration test for testing PyTorch specific features. */
-package integration;
+package ai.djl.pytorch.jni;
+
+/** A helper class allows engine shared library to be loaded from different class loader. */
+public final class NativeHelper {
+
+    private NativeHelper() {}
+
+    /**
+     * Load native shared library from file.
+     *
+     * @param path the file to load
+     */
+    public static void load(String path) {
+        System.load(path); // NOPMD
+    }
+}

--- a/pytorch/pytorch-native/src/main/java/ai/djl/pytorch/jni/package-info.java
+++ b/pytorch/pytorch-native/src/main/java/ai/djl/pytorch/jni/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+/** Contains helper class to load native shared library. */
+package ai.djl.pytorch.jni;


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
