### PR TITLE
make cachedOp threadlocal

### DIFF
--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/CachedOp.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/CachedOp.java
@@ -88,8 +88,11 @@ public class CachedOp extends NativeResource {
     public NDList forward(ParameterStore parameterStore, NDList data, boolean training) {
         // reset the input data index at the beginning
         MxNDArray[] allInputsNDArray = new MxNDArray[parameters.size()];
-        // for unit test purpose, we export the current one to global
-        this.debugInputs = allInputsNDArray;
+        String unitTest = System.getProperty("MXNET_UNIT_TEST");
+        if ("TRUE".equals(unitTest)) {
+            // for unit test purpose, we export the current one to global
+            this.debugInputs = allInputsNDArray;
+        }
         // check device of input
         Device device = data.head().getDevice();
         // get the manager of the data

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/FunctionInfo.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/FunctionInfo.java
@@ -17,7 +17,6 @@ import ai.djl.mxnet.engine.MxNDArray;
 import ai.djl.mxnet.engine.MxNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.types.SparseFormat;
 import ai.djl.training.Trainer;
 import ai.djl.util.PairList;
 import com.sun.jna.Pointer;
@@ -87,17 +86,8 @@ public class FunctionInfo {
     private NDArray[] invoke(MxNDManager manager, PointerArray src, PairList<String, ?> params) {
         PointerByReference destRef = new PointerByReference();
 
-        PairList<Pointer, SparseFormat> pairList =
-                JnaUtils.imperativeInvoke(handle, src, destRef, params);
-        return pairList.stream()
-                .map(
-                        pair -> {
-                            if (pair.getValue() != SparseFormat.DENSE) {
-                                return manager.create(pair.getKey(), pair.getValue());
-                            }
-                            return manager.create(pair.getKey());
-                        })
-                .toArray(MxNDArray[]::new);
+        List<Pointer> list = JnaUtils.imperativeInvoke(handle, src, destRef, params);
+        return list.stream().map(manager::create).toArray(MxNDArray[]::new);
     }
 
     /**

--- a/mxnet/mxnet-engine/src/test/java/ai/djl/mxnet/engine/CachedOpTest.java
+++ b/mxnet/mxnet-engine/src/test/java/ai/djl/mxnet/engine/CachedOpTest.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.IObjectFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
@@ -54,6 +55,12 @@ public class CachedOpTest extends PowerMockTestCase {
         mockStatic(LibUtils.class);
         MxnetLibrary library = new MockMxnetLibrary();
         PowerMockito.when(LibUtils.loadLibrary()).thenReturn(library);
+        System.setProperty("MXNET_UNIT_TEST", "TRUE");
+    }
+
+    @AfterClass
+    public void cleanup() {
+        System.setProperty("MXNET_UNIT_TEST", "FALSE");
     }
 
     @Test(expectedExceptions = NullPointerException.class)


### PR DESCRIPTION
## Description ##

ThreadLocal fix to cachedOp to handle multi-threading inference

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

