### PR TITLE
Add delay thread execution to multithreaded benchmark.

### DIFF
--- a/examples/src/main/java/ai/djl/examples/inference/benchmark/util/Arguments.java
+++ b/examples/src/main/java/ai/djl/examples/inference/benchmark/util/Arguments.java
@@ -47,6 +47,7 @@ public class Arguments {
     private int duration;
     private int iteration;
     private int threads;
+    private int delay;
     private Shape[] inputShapes;
     private boolean help;
 
@@ -73,6 +74,9 @@ public class Arguments {
         if (cmd.hasOption("criteria")) {
             Type type = new TypeToken<Map<String, String>>() {}.getType();
             criteria = JsonUtils.GSON.fromJson(cmd.getOptionValue("criteria"), type);
+        }
+        if (cmd.hasOption("delay")) {
+            delay = Integer.parseInt(cmd.getOptionValue("delay"));
         }
         if (cmd.hasOption("input-shapes")) {
             String shape = cmd.getOptionValue("input-shapes");
@@ -139,6 +143,13 @@ public class Arguments {
                         .hasArg()
                         .argName("NUMBER_THREADS")
                         .desc("Number of inference threads.")
+                        .build());
+        options.addOption(
+                Option.builder("l")
+                        .longOpt("delay")
+                        .hasArg()
+                        .argName("DELAY")
+                        .desc("Delay of incremental threads.")
                         .build());
         options.addOption(
                 Option.builder("o")
@@ -233,6 +244,10 @@ public class Arguments {
             return ImageFactory.getInstance().fromFile(getImageFile());
         }
         return null;
+    }
+
+    public int getDelay() {
+        return delay;
     }
 
     public Shape[] getInputShapes() {


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
