### PR TITLE
Use MXImperativeInvoke instead of MXImperativeInvokeEx

### DIFF
--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/FunctionInfo.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/FunctionInfo.java
@@ -13,7 +13,6 @@
 package ai.djl.mxnet.jna;
 
 import ai.djl.Device;
-import ai.djl.mxnet.engine.MxNDArray;
 import ai.djl.mxnet.engine.MxNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
@@ -57,7 +56,8 @@ public class FunctionInfo {
         checkDevices(dest);
         PointerArray srcHandles = JnaUtils.toPointerArray(src);
         PointerByReference destRef = new PointerByReference(JnaUtils.toPointerArray(dest));
-        return JnaUtils.imperativeInvoke(handle, srcHandles, destRef, params).size();
+        JnaUtils.imperativeInvoke(handle, srcHandles, destRef, params);
+        return 0;
     }
 
     /**
@@ -86,18 +86,17 @@ public class FunctionInfo {
      */
     private NDArray[] invoke(MxNDManager manager, PointerArray src, PairList<String, ?> params) {
         PointerByReference destRef = new PointerByReference();
-
-        PairList<Pointer, SparseFormat> pairList =
-                JnaUtils.imperativeInvoke(handle, src, destRef, params);
-        return pairList.stream()
-                .map(
-                        pair -> {
-                            if (pair.getValue() != SparseFormat.DENSE) {
-                                return manager.create(pair.getKey(), pair.getValue());
-                            }
-                            return manager.create(pair.getKey());
-                        })
-                .toArray(MxNDArray[]::new);
+        Pointer[] pointers = JnaUtils.imperativeInvoke(handle, src, destRef, params);
+        NDArray[] ret = new NDArray[pointers.length];
+        for (int i = 0; i < pointers.length; ++i) {
+            SparseFormat format = JnaUtils.getStorageType(pointers[i]);
+            if (format != SparseFormat.DENSE) {
+                ret[i] = manager.create(pointers[i], format);
+            } else {
+                ret[i] = manager.create(pointers[i]);
+            }
+        }
+        return ret;
     }
 
     /**

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/JnaUtils.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/JnaUtils.java
@@ -481,7 +481,7 @@ public final class JnaUtils {
         checkCall(LIB.MXNDArraySyncCopyFromCPU(ndArray, pointer, size));
     }
 
-    public static PairList<Pointer, SparseFormat> imperativeInvoke(
+    public static Pointer[] imperativeInvoke(
             Pointer function,
             PointerArray inputs,
             PointerByReference destRef,
@@ -495,12 +495,11 @@ public final class JnaUtils {
             keys = params.keyArray(EMPTY_ARRAY);
             values = params.values().stream().map(Object::toString).toArray(String[]::new);
         }
-        PointerByReference destSType = new PointerByReference();
         IntBuffer numOutputs = IntBuffer.allocate(1);
         numOutputs.put(0, 1);
 
         checkCall(
-                LIB.MXImperativeInvokeEx(
+                LIB.MXImperativeInvoke(
                         function,
                         inputs.numElements(),
                         inputs,
@@ -508,16 +507,9 @@ public final class JnaUtils {
                         destRef,
                         keys.length,
                         keys,
-                        values,
-                        destSType));
+                        values));
         int numOfOutputs = numOutputs.get(0);
-        Pointer[] ptrArray = destRef.getValue().getPointerArray(0, numOfOutputs);
-        int[] sTypes = destSType.getValue().getIntArray(0, numOfOutputs);
-        PairList<Pointer, SparseFormat> pairList = new PairList<>();
-        for (int i = 0; i < numOfOutputs; i++) {
-            pairList.add(ptrArray[i], SparseFormat.fromValue(sTypes[i]));
-        }
-        return pairList;
+        return destRef.getValue().getPointerArray(0, numOfOutputs);
     }
 
     public static SparseFormat getStorageType(Pointer ndArray) {
@@ -1721,7 +1713,7 @@ public final class JnaUtils {
      * @param training true if CachedOp is created to forward in traning otherwise, false
      * @return a CachedOp for inference
      */
-    public static CachedOp createCachedOp(
+    public static synchronized CachedOp createCachedOp(
             MxSymbolBlock block, MxNDManager manager, boolean training) {
         Symbol symbol = block.getSymbol();
 
@@ -1781,20 +1773,12 @@ public final class JnaUtils {
         PointerArray array = new PointerArray(inputHandles);
         IntBuffer buf = IntBuffer.allocate(1);
         PointerByReference ref = new PointerByReference();
-        PointerByReference outSTypeRef = new PointerByReference();
-        checkCall(
-                LIB.MXInvokeCachedOpEx(
-                        cachedOpHandle, inputs.length, array, buf, ref, outSTypeRef));
+        checkCall(LIB.MXInvokeCachedOp(cachedOpHandle, inputs.length, array, buf, ref));
         int numOutputs = buf.get();
         Pointer[] ptrArray = ref.getValue().getPointerArray(0, numOutputs);
-        int[] sTypes = outSTypeRef.getValue().getIntArray(0, numOutputs);
         MxNDArray[] output = new MxNDArray[numOutputs];
         for (int i = 0; i < numOutputs; i++) {
-            if (sTypes[i] != 0) {
-                output[i] = manager.create(ptrArray[i], SparseFormat.fromValue(sTypes[i]));
-            } else {
-                output[i] = manager.create(ptrArray[i]);
-            }
+            output[i] = manager.create(ptrArray[i]);
         }
         return output;
     }


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
