### PR TITLE
Fix DataIterable memory leak

### DIFF
--- a/api/src/main/java/ai/djl/training/dataset/DataIterable.java
+++ b/api/src/main/java/ai/djl/training/dataset/DataIterable.java
@@ -188,6 +188,7 @@ public class DataIterable implements Iterable<Batch>, Iterator<Batch> {
             batchLabels = batchLabels.toDevice(device, false);
         }
         return new Batch(
+                subManager,
                 batchData,
                 batchLabels,
                 batchSize,

--- a/basicdataset/src/test/java/ai/djl/basicdataset/DatasetUtilsTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/DatasetUtilsTest.java
@@ -35,11 +35,14 @@ public class DatasetUtilsTest {
             NDArray label = manager.zeros(new Shape(6, 1));
             Batch batch =
                     new Batch(
+                            manager.newSubManager(),
                             new NDList(data),
                             new NDList(label),
                             6,
                             Batchifier.STACK,
-                            Batchifier.STACK);
+                            Batchifier.STACK,
+                            0,
+                            0);
 
             Batch[] split = batch.split(devices, true);
 
@@ -65,11 +68,14 @@ public class DatasetUtilsTest {
             NDArray label = manager.zeros(new Shape(7, 1));
             Batch batch =
                     new Batch(
+                            manager.newSubManager(),
                             new NDList(data),
                             new NDList(label),
                             7,
                             Batchifier.STACK,
-                            Batchifier.STACK);
+                            Batchifier.STACK,
+                            0,
+                            0);
 
             Batch[] split = batch.split(devices, false);
 
@@ -99,11 +105,14 @@ public class DatasetUtilsTest {
             NDArray label = manager.zeros(new Shape(7, 1));
             Batch batch =
                     new Batch(
+                            manager.newSubManager(),
                             new NDList(data),
                             new NDList(label),
                             7,
                             Batchifier.STACK,
-                            Batchifier.STACK);
+                            Batchifier.STACK,
+                            0,
+                            0);
 
             Batch[] split = batch.split(devices, false);
 

--- a/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/AlexNetTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/AlexNetTest.java
@@ -59,11 +59,14 @@ public class AlexNetTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = alexNet.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();
@@ -113,11 +116,14 @@ public class AlexNetTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = alexNet.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();

--- a/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/GoogLeNetTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/GoogLeNetTest.java
@@ -57,11 +57,14 @@ public class GoogLeNetTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = googLeNet.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();

--- a/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/LeNetTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/LeNetTest.java
@@ -58,11 +58,14 @@ public class LeNetTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = leNet.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();
@@ -99,11 +102,14 @@ public class LeNetTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = leNet.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();

--- a/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/NiNTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/NiNTest.java
@@ -57,11 +57,14 @@ public class NiNTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = nin.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();
@@ -110,11 +113,14 @@ public class NiNTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = nin.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();

--- a/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/ResnetTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/ResnetTest.java
@@ -78,11 +78,14 @@ public class ResnetTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = resNet50.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();
@@ -134,11 +137,14 @@ public class ResnetTest {
                 NDArray label = manager.ones(outputShape[0]);
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(data),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 EasyTrain.trainBatch(trainer, batch);
             }
         }

--- a/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/SqueezenetTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/SqueezenetTest.java
@@ -55,11 +55,14 @@ public class SqueezenetTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = squeezeNet.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();

--- a/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/VGGTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/model_zoo/classification/VGGTest.java
@@ -64,11 +64,14 @@ public class VGGTest {
                 NDArray label = manager.ones(new Shape(batchSize, 1));
                 Batch batch =
                         new Batch(
+                                manager.newSubManager(),
                                 new NDList(input),
                                 new NDList(label),
                                 batchSize,
                                 Batchifier.STACK,
-                                Batchifier.STACK);
+                                Batchifier.STACK,
+                                0,
+                                0);
                 PairList<String, Parameter> parameters = vgg.getParameters();
                 EasyTrain.trainBatch(trainer, batch);
                 trainer.step();

--- a/integration/src/main/java/ai/djl/integration/tests/training/OptimizerTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/training/OptimizerTest.java
@@ -300,11 +300,14 @@ public class OptimizerTest {
         NDArray label = data.mul(2);
         Batch batch =
                 new Batch(
+                        manager.newSubManager(),
                         new NDList(data),
                         new NDList(label),
                         batchSize,
                         Batchifier.STACK,
-                        Batchifier.STACK);
+                        Batchifier.STACK,
+                        0,
+                        0);
         EasyTrain.trainBatch(trainer, batch);
         trainer.step();
         return NDArrays.stack(

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -154,8 +154,8 @@ public class MxNDArray extends NativeResource implements LazyNDArray {
     /** {@inheritDoc} */
     @Override
     public NDManager attach(NDManager manager) {
-        detach();
         NDManager original = this.manager;
+        detach();
         this.manager = (MxNDManager) manager;
         manager.attach(getUid(), this);
         return original;


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
