### PR TITLE
bump up pytorch version

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -96,7 +96,7 @@ DJL is engine agnostic, so it's capable of supporting different backends.
 
 With Apache MXNet, PyTorch, TensorFlow and ONNX Runtime, you can choose different builds of the native library.
 We recommend the automatic engine selection which downloads the best engine for your platform and available hardware during the first runtime.
-Activate the automatic selection by adding `ai.djl.mxnet:mxnet-native-auto:1.7.0-backport` for MXNet and `ai.djl.pytorch:pytorch-native-auto:1.6.0` for PyTorh as a dependency.
+Activate the automatic selection by adding `ai.djl.mxnet:mxnet-native-auto:1.7.0-backport` for MXNet and `ai.djl.pytorch:pytorch-native-auto:1.7.0` for PyTorh as a dependency.
 You can also see:
 
 - [MXNet Engine](../mxnet/mxnet-engine/README.md)

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     if (System.getProperty("ai.djl.default_engine") == "PyTorch") {
         runtimeOnly project(":pytorch:pytorch-model-zoo")
-        runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+        runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
     } else if (System.getProperty("ai.djl.default_engine") == "TensorFlow") {
         runtimeOnly project(":tensorflow:tensorflow-model-zoo")
         runtimeOnly "ai.djl.tensorflow:tensorflow-native-auto:${tensorflow_version}"

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     if (System.getProperty("ai.djl.default_engine") == "PyTorch") {
         runtimeOnly project(":pytorch:pytorch-engine")
         runtimeOnly project(":pytorch:pytorch-model-zoo")
-        runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+        runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
     } else if (System.getProperty("ai.djl.default_engine") == "TensorFlow") {
         runtimeOnly project(":tensorflow:tensorflow-engine")
         runtimeOnly "ai.djl.tensorflow:tensorflow-native-auto:${tensorflow_version}"

--- a/onnxruntime/onnxruntime-engine/build.gradle
+++ b/onnxruntime/onnxruntime-engine/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     }
 
     testRuntimeOnly project(":pytorch:pytorch-engine")
-    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
     testRuntimeOnly "org.slf4j:slf4j-simple:${slf4j_version}"
 }
 

--- a/pytorch/pytorch-engine/README.md
+++ b/pytorch/pytorch-engine/README.md
@@ -44,13 +44,13 @@ Choose a native library based on your platform and needs:
 We offer an automatic option that will download the native libraries into [cache folder](../../docs/development/cache_management.md) the first time you run DJL.
 It will automatically determine the appropriate jars for your system based on the platform and GPU support.
 
-- ai.djl.pytorch:pytorch-native-auto:1.6.0
+- ai.djl.pytorch:pytorch-native-auto:1.7.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-auto</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -58,14 +58,14 @@ It will automatically determine the appropriate jars for your system based on th
 ### macOS
 For macOS, you can use the following library:
 
-- ai.djl.pytorch:pytorch-native-cpu:1.6.0:osx-x86_64
+- ai.djl.pytorch:pytorch-native-cpu:1.7.0:osx-x86_64
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cpu</artifactId>
     <classifier>osx-x86_64</classifier>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -76,15 +76,26 @@ installed on your GPU machine, you can use one of the following library:
 
 #### Linux GPU
 
-- ai.djl.pytorch:pytorch-native-cu102:1.6.0:linux-x86_64 - CUDA 10.2
-- ai.djl.pytorch:pytorch-native-cu101:1.6.0:linux-x86_64 - CUDA 10.1
+- ai.djl.pytorch:pytorch-native-cu110:1.7.0:linux-x86_64 - CUDA 11.0
+- ai.djl.pytorch:pytorch-native-cu102:1.7.0:linux-x86_64 - CUDA 10.2
+- ai.djl.pytorch:pytorch-native-cu101:1.7.0:linux-x86_64 - CUDA 10.1
+
+```xml
+<dependency>
+    <groupId>ai.djl.pytorch</groupId>
+    <artifactId>pytorch-native-cu110</artifactId>
+    <classifier>linux-x86_64</classifier>
+    <version>1.7.0</version>
+    <scope>runtime</scope>
+</dependency>
+```
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu102</artifactId>
     <classifier>linux-x86_64</classifier>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -94,24 +105,14 @@ installed on your GPU machine, you can use one of the following library:
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu101</artifactId>
     <classifier>linux-x86_64</classifier>
-    <version>1.6.0</version>
-    <scope>runtime</scope>
-</dependency>
-```
-
-```xml
-<dependency>
-    <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-cu92</artifactId>
-    <classifier>linux-x86_64</classifier>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
 
 ### Linux CPU
 
-- ai.djl.pytorch:pytorch-native-cpu:1.6.0:linux-x86_64
+- ai.djl.pytorch:pytorch-native-cpu:1.7.0:linux-x86_64
 
 ```xml
 <dependency>
@@ -119,7 +120,7 @@ installed on your GPU machine, you can use one of the following library:
     <artifactId>pytorch-native-cpu</artifactId>
     <classifier>linux-x86_64</classifier>
     <scope>runtime</scope>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
 </dependency>
 ```
 
@@ -131,7 +132,7 @@ All the package were built with GCC 7, we provided a newer `libstdc++.so.6.24` i
 Users are required to use the corresponding `pytorch-engine` package along with the native package.
 
 - ai.djl.pytorch:pytorch-engine-precxx11:0.8.0
-- ai.djl.pytorch:pytorch-native-cpu-precxx11:1.6.0:linux-x86_64
+- ai.djl.pytorch:pytorch-native-cpu-precxx11:1.7.0:linux-x86_64
 
 ```xml
 <dependency>
@@ -144,7 +145,7 @@ Users are required to use the corresponding `pytorch-engine` package along with 
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cpu-precxx11</artifactId>
     <classifier>linux-x86_64</classifier>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -155,15 +156,16 @@ For the Windows platform, you can choose between CPU and GPU.
 
 #### Windows GPU
 
-- ai.djl.pytorch:pytorch-native-cu102:1.6.0:win-x86_64
-- ai.djl.pytorch:pytorch-native-cu101:1.6.0:win-x86_64
+- ai.djl.pytorch:pytorch-native-cu110:1.7.0:win-x86_64
+- ai.djl.pytorch:pytorch-native-cu102:1.7.0:win-x86_64
+- ai.djl.pytorch:pytorch-native-cu101:1.7.0:win-x86_64
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu102</artifactId>
     <classifier>win-x86_64</classifier>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -173,14 +175,14 @@ For the Windows platform, you can choose between CPU and GPU.
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu101</artifactId>
     <classifier>win-x86_64</classifier>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
 
 ### Windows CPU
 
-- ai.djl.pytorch:pytorch-native-cpu:1.6.0:win-x86_64
+- ai.djl.pytorch:pytorch-native-cpu:1.7.0:win-x86_64
 
 ```xml
 <dependency>
@@ -188,6 +190,6 @@ For the Windows platform, you can choose between CPU and GPU.
     <artifactId>pytorch-native-cpu</artifactId>
     <classifier>win-x86_64</classifier>
     <scope>runtime</scope>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
 </dependency>
 ```

--- a/pytorch/pytorch-engine/build.gradle
+++ b/pytorch/pytorch-engine/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     }
     testImplementation "org.slf4j:slf4j-simple:${slf4j_version}"
     testRuntimeOnly project(":pytorch:pytorch-model-zoo")
-    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
 }
 
 processResources {

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
@@ -65,7 +65,7 @@ public final class PtEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public String getVersion() {
-        return "1.6.0";
+        return "1.7.0";
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Description ##

bump up pytorch instruction to 1.7.0

Note: PyTorch 1.7.0 only works on 0.9.0-SNAPSHOT and official 0.9.0. So there is no changes to examples until we release 0.9.0

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [x] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change
