### PR TITLE
Make Engine.setRandomSeed() consistent across engines

### DIFF
--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
@@ -20,6 +20,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.pytorch.jni.JniUtils;
 import ai.djl.pytorch.jni.LibUtils;
 import ai.djl.training.GradientCollector;
+import ai.djl.util.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +103,7 @@ public final class PtEngine extends Engine {
     @Override
     public void setRandomSeed(int seed) {
         JniUtils.setSeed(seed);
+        RandomUtils.RANDOM.setSeed(seed);
     }
 
     /** {@inheritDoc} */

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
@@ -19,6 +19,7 @@ import ai.djl.engine.EngineException;
 import ai.djl.engine.StandardCapabilities;
 import ai.djl.ndarray.NDManager;
 import ai.djl.training.GradientCollector;
+import ai.djl.util.RandomUtils;
 import org.tensorflow.EagerSession;
 import org.tensorflow.TensorFlow;
 import org.tensorflow.internal.c_api.TF_DeviceList;
@@ -114,6 +115,7 @@ public final class TfEngine extends Engine {
     @Override
     public void setRandomSeed(int seed) {
         TfNDManager.setRandomSeed(seed);
+        RandomUtils.RANDOM.setSeed(seed);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
