### PR TITLE
Replace native download url to cloudfront url

### DIFF
--- a/android/pytorch-native/build.gradle
+++ b/android/pytorch-native/build.gradle
@@ -105,7 +105,7 @@ afterEvaluate {
 
 task processResources {
     doLast {
-        def url = "https://djl-ai.s3.amazonaws.com/publish/pytorch-${pytorch_version}/jnilib/${djl_version}/android"
+        def url = "https://publish.djl.ai/pytorch-${pytorch_version}/jnilib/${djl_version}/android"
         def abis = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
         abis.each { abi ->
             def downloadPath = new URL("${url}/${abi}/libdjl_torch.so")

--- a/extensions/fasttext/build.gradle
+++ b/extensions/fasttext/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 processResources {
     outputs.dir file("${project.buildDir}/classes/java/main/native/lib")
     doLast {
-        def url = "https://djl-ai.s3.amazonaws.com/publish/fasttext-${fasttext_version}/jnilib/${djl_version}"
+        def url = "https://publish.djl.ai/fasttext-${fasttext_version}/jnilib/${djl_version}"
         def files = [
                 "linux-x86_64": "libjni_fasttext.so",
                 "osx-x86_64"  : "libjni_fasttext.dylib"

--- a/extensions/sentencepiece/build.gradle
+++ b/extensions/sentencepiece/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 processResources {
     outputs.dir file("${project.buildDir}/classes/java/main/native/lib")
     doLast {
-        def url = "https://djl-ai.s3.amazonaws.com/publish/sentencepiece-${sentencepiece_version}/jnilib/${djl_version}"
+        def url = "https://publish.djl.ai/sentencepiece-${sentencepiece_version}/jnilib/${djl_version}"
         def files = [
                 "linux-x86_64": "libsentencepiece_native.so",
                 "osx-x86_64"  : "libsentencepiece_native.dylib"

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/LibUtils.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/LibUtils.java
@@ -282,7 +282,7 @@ public final class LibUtils {
         if (!matcher.matches()) {
             throw new IllegalArgumentException("Unexpected version: " + version);
         }
-        String link = "https://djl-ai.s3.amazonaws.com/publish/mxnet-" + matcher.group(1);
+        String link = "https://publish.djl.ai/mxnet-" + matcher.group(1);
         try (InputStream is = new URL(link + "/files.txt").openStream()) {
             List<String> lines = Utils.readLines(is);
             if (cudaArch != null) {

--- a/mxnet/native/build.gradle
+++ b/mxnet/native/build.gradle
@@ -164,7 +164,7 @@ import java.util.zip.GZIPInputStream
 
 task downloadMxnetNativeLib() {
     doLast {
-        def url = "https://djl-ai.s3.amazonaws.com/publish/mxnet-${VERSION}"
+        def url = "https://publish.djl.ai/mxnet-${VERSION}"
         def files = [
                 "linux/common/libgfortran.so.3.gz": "mkl/linux/native/lib/libgfortran.so.3",
                 "linux/common/libgomp.so.1.gz"    : "mkl/linux/native/lib/libgomp.so.1",

--- a/pytorch/pytorch-engine/build.gradle
+++ b/pytorch/pytorch-engine/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 processResources {
     outputs.dir file("${project.buildDir}/jnilib")
     doLast {
-        def url = "https://djl-ai.s3.amazonaws.com/publish/pytorch-${pytorch_version}/jnilib/${djl_version}"
+        def url = "https://publish.djl.ai/pytorch-${pytorch_version}/jnilib/${djl_version}"
         def files = [
                 "linux-x86_64/cpu/libdjl_torch.so"         : "linux-x86_64/cpu/libdjl_torch.so",
                 "linux-x86_64/cu101/libdjl_torch.so"       : "linux-x86_64/cu101/libdjl_torch.so",

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -357,7 +357,7 @@ public final class LibUtils {
         if (!matcher.matches()) {
             throw new IllegalArgumentException("Unexpected version: " + version);
         }
-        String link = "https://djl-ai.s3.amazonaws.com/publish/pytorch-" + matcher.group(1);
+        String link = "https://publish.djl.ai/pytorch-" + matcher.group(1);
         Path tmp = null;
         try (InputStream is = new URL(link + "/files.txt").openStream()) {
             List<String> lines = Utils.readLines(is);

--- a/pytorch/pytorch-native/build.gradle
+++ b/pytorch/pytorch-native/build.gradle
@@ -235,7 +235,7 @@ task downloadPyTorchNativeLib() {
             }
             if (isPrecxx11) {
                 def libstd = new File("${outputDir}/native/lib/libstdc++.so.6")
-                new URL("https://djl-ai.s3.amazonaws.com/publish/extra/libstdc%2B%2B.so.6").withInputStream {
+                new URL("https://publish.djl.ai/extra/libstdc%2B%2B.so.6").withInputStream {
                     i -> libstd.withOutputStream { it << i }
                 }
             }
@@ -287,7 +287,7 @@ flavorNames.each { flavor ->
 
                 if (isPrecxx11) {
                     def libstd = new File(metaInf, "ATTRIBUTION")
-                    libstd.text = new URL("https://djl-ai.s3.amazonaws.com/publish/extra/THIRD-PARTY-LICENSES_qHnMKgbdWa.txt").text
+                    libstd.text = new URL("https://publish.djl.ai/extra/THIRD-PARTY-LICENSES_qHnMKgbdWa.txt").text
                 }
             }
             from file("${BINARY_ROOT}/${flavor}/${osName}")

--- a/pytorch/pytorch-native/build_android.sh
+++ b/pytorch/pytorch-native/build_android.sh
@@ -18,7 +18,7 @@ if [[ ! -d libtorch_android/"$1" ]]; then
     else
         mkdir -p libtorch_android/"$1"
         cd libtorch_android/"$1"
-        curl -s https://djl-ai.s3.amazonaws.com/publish/pytorch-"{$VERSION}/android_native/{$1}"_native.zip | jar xv
+        curl -s https://publish.djl.ai/pytorch-"{$VERSION}/android_native/{$1}"_native.zip | jar xv
         cd ../../
     fi
 fi

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/LibUtils.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/LibUtils.java
@@ -225,7 +225,7 @@ public final class LibUtils {
         if (!matcher.matches()) {
             throw new IllegalArgumentException("Unexpected version: " + version);
         }
-        String link = "https://djl-ai.s3.amazonaws.com/publish/tensorflow-" + matcher.group(1);
+        String link = "https://publish.djl.ai/tensorflow-" + matcher.group(1);
         try (InputStream is = new URL(link + "/files.txt").openStream()) {
             List<String> lines = Utils.readLines(is);
             boolean found = downloadFiles(lines, link, os, flavor, tmp);

--- a/tensorflow/tensorflow-native/build.gradle
+++ b/tensorflow/tensorflow-native/build.gradle
@@ -243,7 +243,7 @@ import java.util.zip.GZIPInputStream
 
 task downloadTensorflowNativeLib() {
     doLast {
-        def url = "https://djl-ai.s3.amazonaws.com/publish/tensorflow-${tensorflow_version}"
+        def url = "https://publish.djl.ai/tensorflow-${tensorflow_version}"
         def files = [
                 "linux/cpu/libjnitensorflow.so.gz"                        : "cpu/linux/native/lib/libjnitensorflow.so",
                 "linux/cpu/libtensorflow_cc.so.2.gz"                      : "cpu/linux/native/lib/libtensorflow_cc.so.2",


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
