### PR TITLE
TopKAccuracy accepts both int32 and int64 for pred and label

### DIFF
--- a/api/src/main/java/ai/djl/training/evaluator/TopKAccuracy.java
+++ b/api/src/main/java/ai/djl/training/evaluator/TopKAccuracy.java
@@ -75,7 +75,7 @@ public class TopKAccuracy extends AbstractAccuracy {
         // number of labels and predictions should be the same
         checkLabelShapes(label, prediction);
         // ascending by default
-        NDArray topKPrediction = prediction.argSort(axis).toType(DataType.INT32, false);
+        NDArray topKPrediction = prediction.argSort(axis).toType(DataType.INT64, false);
         int numDims = topKPrediction.getShape().dimension();
         NDArray numCorrect;
         if (numDims == 1) {
@@ -94,7 +94,7 @@ public class TopKAccuracy extends AbstractAccuracy {
                                                                 ":, {}", numClasses - j - 1);
                                                 return jPrediction
                                                         .flatten()
-                                                        .eq(label.flatten())
+                                                    .eq(label.flatten().toType(DataType.INT64, false))
                                                         .countNonzero();
                                             })
                                     .toArray(NDArray[]::new));

--- a/api/src/main/java/ai/djl/training/evaluator/TopKAccuracy.java
+++ b/api/src/main/java/ai/djl/training/evaluator/TopKAccuracy.java
@@ -94,7 +94,11 @@ public class TopKAccuracy extends AbstractAccuracy {
                                                                 ":, {}", numClasses - j - 1);
                                                 return jPrediction
                                                         .flatten()
-                                                    .eq(label.flatten().toType(DataType.INT64, false))
+                                                        .eq(
+                                                                label.flatten()
+                                                                        .toType(
+                                                                                DataType.INT64,
+                                                                                false))
                                                         .countNonzero();
                                             })
                                     .toArray(NDArray[]::new));

--- a/integration/src/main/java/ai/djl/integration/tests/training/EvaluatorTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/training/EvaluatorTest.java
@@ -42,6 +42,18 @@ public class EvaluatorTest {
                     accuracy,
                     expectedAccuracy,
                     "Wrong accuracy, expected: " + expectedAccuracy + ", actual: " + accuracy);
+
+            labels = manager.create(new long[] {0, 1, 1}, new Shape(3));
+
+            acc = new Accuracy();
+            acc.addAccumulator("");
+            acc.updateAccumulator("", new NDList(labels), new NDList(predictions));
+            accuracy = acc.getAccumulator("");
+            expectedAccuracy = 2.f / 3;
+            Assert.assertEquals(
+                    accuracy,
+                    expectedAccuracy,
+                    "Wrong accuracy, expected: " + expectedAccuracy + ", actual: " + accuracy);
         }
     }
 
@@ -60,6 +72,17 @@ public class EvaluatorTest {
             topKAccuracy.updateAccumulator("", new NDList(labels), new NDList(predictions));
             float expectedAccuracy = 1.f / 3;
             float accuracy = topKAccuracy.getAccumulator("");
+            Assert.assertEquals(
+                    accuracy,
+                    expectedAccuracy,
+                    "Wrong accuracy, expected: " + expectedAccuracy + ", actual: " + accuracy);
+
+            labels = manager.create(new long[] {0, 1, 2}, new Shape(3));
+            topKAccuracy = new TopKAccuracy(2);
+            topKAccuracy.addAccumulator("");
+            topKAccuracy.updateAccumulator("", new NDList(labels), new NDList(predictions));
+            expectedAccuracy = 1.f / 3;
+            accuracy = topKAccuracy.getAccumulator("");
             Assert.assertEquals(
                     accuracy,
                     expectedAccuracy,


### PR DESCRIPTION
## Description ##
In TopKAccuracy, pred and label could accept data type both int32 and int64.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- [X] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [X] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] accuracyHelper in TopKAccuracy.java
- [x] corresponding integration test in EvaluatorTest.java

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
