### PR TITLE
Revert pytorch engine document to use 1.6.0

### DIFF
--- a/pytorch/pytorch-engine/README.md
+++ b/pytorch/pytorch-engine/README.md
@@ -44,13 +44,13 @@ Choose a native library based on your platform and needs:
 We offer an automatic option that will download the native libraries into [cache folder](../../docs/development/cache_management.md) the first time you run DJL.
 It will automatically determine the appropriate jars for your system based on the platform and GPU support.
 
-- ai.djl.pytorch:pytorch-native-auto:1.7.0
+- ai.djl.pytorch:pytorch-native-auto:1.6.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-auto</artifactId>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -58,14 +58,14 @@ It will automatically determine the appropriate jars for your system based on th
 ### macOS
 For macOS, you can use the following library:
 
-- ai.djl.pytorch:pytorch-native-cpu:1.7.0:osx-x86_64
+- ai.djl.pytorch:pytorch-native-cpu:1.6.0:osx-x86_64
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cpu</artifactId>
     <classifier>osx-x86_64</classifier>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -76,26 +76,15 @@ installed on your GPU machine, you can use one of the following library:
 
 #### Linux GPU
 
-- ai.djl.pytorch:pytorch-native-cu110:1.7.0:linux-x86_64 - CUDA 11.0
-- ai.djl.pytorch:pytorch-native-cu102:1.7.0:linux-x86_64 - CUDA 10.2
-- ai.djl.pytorch:pytorch-native-cu101:1.7.0:linux-x86_64 - CUDA 10.1
-
-```xml
-<dependency>
-    <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-cu110</artifactId>
-    <classifier>linux-x86_64</classifier>
-    <version>1.7.0</version>
-    <scope>runtime</scope>
-</dependency>
-```
+- ai.djl.pytorch:pytorch-native-cu102:1.6.0:linux-x86_64 - CUDA 10.2
+- ai.djl.pytorch:pytorch-native-cu101:1.6.0:linux-x86_64 - CUDA 10.1
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu102</artifactId>
     <classifier>linux-x86_64</classifier>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -105,14 +94,14 @@ installed on your GPU machine, you can use one of the following library:
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu101</artifactId>
     <classifier>linux-x86_64</classifier>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
 
 ### Linux CPU
 
-- ai.djl.pytorch:pytorch-native-cpu:1.7.0:linux-x86_64
+- ai.djl.pytorch:pytorch-native-cpu:1.6.0:linux-x86_64
 
 ```xml
 <dependency>
@@ -120,7 +109,7 @@ installed on your GPU machine, you can use one of the following library:
     <artifactId>pytorch-native-cpu</artifactId>
     <classifier>linux-x86_64</classifier>
     <scope>runtime</scope>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
 </dependency>
 ```
 
@@ -132,7 +121,7 @@ All the package were built with GCC 7, we provided a newer `libstdc++.so.6.24` i
 Users are required to use the corresponding `pytorch-engine` package along with the native package.
 
 - ai.djl.pytorch:pytorch-engine-precxx11:0.8.0
-- ai.djl.pytorch:pytorch-native-cpu-precxx11:1.7.0:linux-x86_64
+- ai.djl.pytorch:pytorch-native-cpu-precxx11:1.6.0:linux-x86_64
 
 ```xml
 <dependency>
@@ -145,7 +134,7 @@ Users are required to use the corresponding `pytorch-engine` package along with 
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cpu-precxx11</artifactId>
     <classifier>linux-x86_64</classifier>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -160,33 +149,22 @@ For the Windows platform, you can choose between CPU and GPU.
 
 #### Windows GPU
 
-- ai.djl.pytorch:pytorch-native-cu110:1.7.0:win-x86_64
-- ai.djl.pytorch:pytorch-native-cu102:1.7.0:win-x86_64
-- ai.djl.pytorch:pytorch-native-cu101:1.7.0:win-x86_64
-
-```xml
-<dependency>
-    <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-cu102</artifactId>
-    <classifier>win-x86_64</classifier>
-    <version>1.7.0</version>
-    <scope>runtime</scope>
-</dependency>
-```
+- ai.djl.pytorch:pytorch-native-cu102:1.6.0:win-x86_64
+- ai.djl.pytorch:pytorch-native-cu101:1.6.0:win-x86_64
 
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu101</artifactId>
     <classifier>win-x86_64</classifier>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
 
 ### Windows CPU
 
-- ai.djl.pytorch:pytorch-native-cpu:1.7.0:win-x86_64
+- ai.djl.pytorch:pytorch-native-cpu:1.6.0:win-x86_64
 
 ```xml
 <dependency>
@@ -194,6 +172,6 @@ For the Windows platform, you can choose between CPU and GPU.
     <artifactId>pytorch-native-cpu</artifactId>
     <classifier>win-x86_64</classifier>
     <scope>runtime</scope>
-    <version>1.7.0</version>
+    <version>1.6.0</version>
 </dependency>
 ```


### PR DESCRIPTION
## Channel for questions ##
Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!


## Description ##
(Brief description of what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
    - For user-facing API changes, Java doc has been updated. 
    - For new examples, README.md is added to explain the what the example does.
- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, Java doc)
- [ ] Feature2, tests, (and when applicable, Java doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
