### PR TITLE
Simplify the PR and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,11 +8,12 @@ assignees: ''
 ---
 
 ## Description
+
 (A clear and concise description of what the feature is.)
 
-### Will this change the current api? How?
+Will this change the current api? How?
 
-### Who will benefit from this enhancement?
+Who will benefit from this enhancement?
 
 ## References
 - list reference and related literature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,6 @@
-## Channel for questions ##
-Before or while filing an issue please feel free to join our [Slack channel](https://join.slack.com/t/deepjavalibrary/shared_invite/zt-ar91gjkz-qbXhr1l~LFGEIEeGBibT7w) to get in touch with development team, ask questions, find out what's cooking and more!
-
-
 ## Description ##
-(Brief description of what this PR is about)
 
-## Checklist ##
-### Essentials ###
-Please feel free to remove inapplicable items for your PR.
-- [ ] Changes are complete (i.e. I finished coding on this PR)
-- [ ] All changes have test coverage:
-- [ ] Code is well-documented: 
-    - For user-facing API changes, Java doc has been updated. 
-    - For new examples, README.md is added to explain the what the example does.
-- [ ] To the my best knowledge, [examples](https://github.com/awslabs/djl/tree/master/examples) and [jupyter notebooks](https://github.com/awslabs/djl/tree/master/jupyter) are either not affected by this change, or have been fixed to be compatible with this change
+Brief description of what this PR is about
 
-### Changes ###
-- [ ] Feature1, tests, (and when applicable, Java doc)
-- [ ] Feature2, tests, (and when applicable, Java doc)
-
-## Comments ##
 - If this change is a backward incompatible change, why must this change be made?
 - Interesting edge cases to note here


### PR DESCRIPTION
## Description ##
The templates right now are quite long and may deter potential contributors. I
think we can remove much of the content without detracting from the meaningful
information we expect to be conveyed.