### PR TITLE
Update jupyter notebook to use pytorch 1.7.0

### DIFF
--- a/jupyter/BERTQA.ipynb
+++ b/jupyter/BERTQA.ipynb
@@ -59,7 +59,7 @@
     "// and See https://github.com/awslabs/djl/blob/master/pytorch/pytorch-engine/README.md\n",
     "// for more engine library selection options\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport\n",
-    "%maven ai.djl.pytorch:pytorch-native-auto:1.6.0"
+    "%maven ai.djl.pytorch:pytorch-native-auto:1.7.0"
    ]
   },
   {

--- a/jupyter/load_pytorch_model.ipynb
+++ b/jupyter/load_pytorch_model.ipynb
@@ -33,7 +33,7 @@
     "        \n",
     "// See https://github.com/awslabs/djl/blob/master/pytorch/pytorch-engine/README.md\n",
     "// for more PyTorch library selection options\n",
-    "%maven ai.djl.pytorch:pytorch-native-auto:1.6.0"
+    "%maven ai.djl.pytorch:pytorch-native-auto:1.7.0"
    ]
   },
   {

--- a/jupyter/onnxruntime/machine_learning_with_ONNXRuntime.ipynb
+++ b/jupyter/onnxruntime/machine_learning_with_ONNXRuntime.ipynb
@@ -61,7 +61,7 @@
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "\n",
     "%maven com.microsoft.onnxruntime:onnxruntime:1.4.0\n",
-    "%maven ai.djl.pytorch:pytorch-native-auto:1.6.0"
+    "%maven ai.djl.pytorch:pytorch-native-auto:1.7.0"
    ]
   },
   {

--- a/jupyter/pytorch/load_your_own_pytorch_bert.ipynb
+++ b/jupyter/pytorch/load_your_own_pytorch_bert.ipynb
@@ -50,7 +50,7 @@
     "        \n",
     "// See https://github.com/awslabs/djl/blob/master/pytorch/pytorch-engine/README.md\n",
     "// for more PyTorch library selection options\n",
-    "%maven ai.djl.pytorch:pytorch-native-auto:1.6.0"
+    "%maven ai.djl.pytorch:pytorch-native-auto:1.7.0"
    ]
   },
   {

--- a/pytorch/pytorch-engine/README.md
+++ b/pytorch/pytorch-engine/README.md
@@ -158,6 +158,16 @@ For the Windows platform, you can choose between CPU and GPU.
 ```xml
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
+    <artifactId>pytorch-native-cu110</artifactId>
+    <classifier>win-x86_64</classifier>
+    <version>1.7.0</version>
+    <scope>runtime</scope>
+</dependency>
+```
+
+```xml
+<dependency>
+    <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-native-cu102</artifactId>
     <classifier>win-x86_64</classifier>
     <version>1.7.0</version>


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
