### PR TITLE
[PyTorch] Correct the precxx jni download path

### DIFF
--- a/pytorch/pytorch-engine/build.gradle
+++ b/pytorch/pytorch-engine/build.gradle
@@ -20,18 +20,18 @@ dependencies {
 processResources {
     outputs.dir file("${project.buildDir}/jnilib")
     doLast {
-        def url = "https://publish.djl.ai/pytorch-${pytorch_version}/jnilib/${djl_version}"
+        def url = "https://publish.djl.ai/pytorch-${pytorch_version}/jnilib"
         def files = [
-                "linux-x86_64/cpu/libdjl_torch.so"         : "linux-x86_64/cpu/libdjl_torch.so",
-                "linux-x86_64/cu101/libdjl_torch.so"       : "linux-x86_64/cu101/libdjl_torch.so",
-                "linux-x86_64/cu102/libdjl_torch.so"       : "linux-x86_64/cu102/libdjl_torch.so",
-                "linux-x86_64/cu110/libdjl_torch.so"       : "linux-x86_64/cu110/libdjl_torch.so",
-                "precxx11/linux-x86_64/cpu/libdjl_torch.so": "linux-x86_64/cpu-precxx11/libdjl_torch.so",
-                "osx-x86_64/cpu/libdjl_torch.dylib"        : "osx-x86_64/cpu/libdjl_torch.dylib",
-                "win-x86_64/cpu/djl_torch.dll"             : "win-x86_64/cpu/djl_torch.dll",
-                "win-x86_64/cu101/djl_torch.dll"           : "win-x86_64/cu101/djl_torch.dll",
-                "win-x86_64/cu102/djl_torch.dll"           : "win-x86_64/cu102/djl_torch.dll",
-                "win-x86_64/cu110/djl_torch.dll"           : "win-x86_64/cu110/djl_torch.dll"
+                "${djl_version}/linux-x86_64/cpu/libdjl_torch.so"         : "linux-x86_64/cpu/libdjl_torch.so",
+                "${djl_version}/linux-x86_64/cu101/libdjl_torch.so"       : "linux-x86_64/cu101/libdjl_torch.so",
+                "${djl_version}/linux-x86_64/cu102/libdjl_torch.so"       : "linux-x86_64/cu102/libdjl_torch.so",
+                "${djl_version}/linux-x86_64/cu110/libdjl_torch.so"       : "linux-x86_64/cu110/libdjl_torch.so",
+                "precxx11/${djl_version}/linux-x86_64/cpu/libdjl_torch.so": "linux-x86_64/cpu-precxx11/libdjl_torch.so",
+                "${djl_version}/osx-x86_64/cpu/libdjl_torch.dylib"        : "osx-x86_64/cpu/libdjl_torch.dylib",
+                "${djl_version}/win-x86_64/cpu/djl_torch.dll"             : "win-x86_64/cpu/djl_torch.dll",
+                "${djl_version}/win-x86_64/cu101/djl_torch.dll"           : "win-x86_64/cu101/djl_torch.dll",
+                "${djl_version}/win-x86_64/cu102/djl_torch.dll"           : "win-x86_64/cu102/djl_torch.dll",
+                "${djl_version}/win-x86_64/cu110/djl_torch.dll"           : "win-x86_64/cu110/djl_torch.dll"
         ]
         def classesDir = "${project.buildDir}/jnilib"
         files.each { entry ->


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
