### PR TITLE
[paddle] Update jupyter notebook to 0.10.0-SNAPSHOT version

### DIFF
--- a/jupyter/paddlepaddle/face_mask_detection_paddlepaddle.ipynb
+++ b/jupyter/paddlepaddle/face_mask_detection_paddlepaddle.ipynb
@@ -26,14 +26,15 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.9.0-SNAPSHOT\n",
-    "%maven ai.djl.paddlepaddle:paddlepaddle-model-zoo:0.9.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.9.0\n",
+    "%maven ai.djl.paddlepaddle:paddlepaddle-model-zoo:0.10.0-SNAPSHOT\n",
     "%maven ai.djl.paddlepaddle:paddlepaddle-native-auto:2.0.0-SNAPSHOT\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "%maven net.java.dev.jna:jna:5.3.0\n",
+    "\n",
     "// second engine to do preprocessing and postprocessing\n",
-    "%maven ai.djl.pytorch:pytorch-engine:0.9.0-SNAPSHOT\n",
+    "%maven ai.djl.pytorch:pytorch-engine:0.9.0\n",
     "%maven ai.djl.pytorch:pytorch-native-auto:1.7.0"
    ]
   },


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
