### PR TITLE
Making MXNet load on linux under RTLD_LOCAL

### DIFF
--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/LibUtils.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/LibUtils.java
@@ -14,6 +14,7 @@ package ai.djl.mxnet.jna;
 
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
+import com.sun.jna.Library;
 import com.sun.jna.Native;
 import java.io.File;
 import java.io.IOException;
@@ -27,6 +28,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
@@ -61,6 +64,13 @@ public final class LibUtils {
     public static MxnetLibrary loadLibrary() {
         String libName = getLibName();
         logger.debug("Loading mxnet library from: {}", libName);
+
+        if (System.getProperty("os.name").startsWith("Linux")) {
+            Map<String, Integer> options = new ConcurrentHashMap<>();
+            int rtld = 1; // Linux RTLD lazy + local
+            options.put(Library.OPTION_OPEN_FLAGS, rtld);
+            return Native.load(libName, MxnetLibrary.class, options);
+        }
 
         return Native.load(libName, MxnetLibrary.class);
     }


### PR DESCRIPTION
## Description ##

By default, JNA will load in RTLD_GLOBAL on Linux. This change wil make it to RTLD_LOCAL, which means its loaded native binaries will have no impact to the other packages loaded.