### PR TITLE
[Paddle] fix linux rpath issue

### DIFF
--- a/paddlepaddle/paddlepaddle-native/CMakeLists.txt
+++ b/paddlepaddle/paddlepaddle-native/CMakeLists.txt
@@ -27,6 +27,12 @@ target_include_directories(djl_paddle PUBLIC
     build/include)
 target_link_libraries(djl_paddle ${PADDLE_LIBRARY})
 
+# We have to kill the default rpath and use current dir
+set(CMAKE_SKIP_RPATH TRUE)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set_target_properties(djl_paddle PROPERTIES LINK_FLAGS "-Wl,-rpath,$ORIGIN")
+endif()
+
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif(MSVC)


### PR DESCRIPTION
## Description ##

Current rpath settings in paddlepaddle are absolute paths. This will make the jni not usable if we build from one place and use it in different places. This changes follows the modification we did on pytorch to add the rpath to Paddle JNI.
