### PR TITLE
Use custom NDK version instead of action default NDK

### DIFF
--- a/.github/workflows/native_jni_s3_pytorch_android.yml
+++ b/.github/workflows/native_jni_s3_pytorch_android.yml
@@ -23,10 +23,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Install NDK
-        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}"
       - name: build android
         run: |
-          export ANDROID_NDK=${ANDROID_HOME}/ndk-bundle
+          export ANDROID_NDK=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}
           ./gradlew :pytorch:pytorch-native:compileAndroidJNI
       - name: Upload compiled jni library
         uses: actions/upload-artifact@v1

--- a/.github/workflows/native_release_pytorch_android.yml
+++ b/.github/workflows/native_release_pytorch_android.yml
@@ -22,10 +22,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Install NDK
-        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}"
       - name: publish android core to staging
         run: |
-          export ANDROID_NDK=${ANDROID_HOME}/ndk-bundle
+          export ANDROID_NDK=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}
           cd android
           ./gradlew :pytorch-native:assemble
           ./gradlew publish -Pstaging

--- a/.github/workflows/native_s3_pytorch_android.yml
+++ b/.github/workflows/native_s3_pytorch_android.yml
@@ -28,10 +28,10 @@ jobs:
       - name: install Python Dependencies
         run: pip install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi
       - name: Install NDK
-        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}"
       - name: build android
         run: |
-          export ANDROID_NDK=${ANDROID_HOME}/ndk-bundle
+          export ANDROID_NDK=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}
           export ANDROID_ABI=${{ matrix.format }}
           cd android_pytorch_tmp
           bash ./scripts/build_android.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -167,10 +167,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Install NDK
-        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${NDK_VERSION}"
       - name: publish android package to Snapshot
         run: |
-          export ANDROID_NDK=${ANDROID_HOME}/ndk-bundle
+          export ANDROID_NDK=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}
           cd android
           ./gradlew :pytorch-native:assemble
           ./gradlew publish -Psnapshot


### PR DESCRIPTION
PyTorch Android native build only works on NDK version 20.
Action uses version 22 by default.