### PR TITLE
Fix NDArray slice size

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullSlice.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullSlice.java
@@ -157,7 +157,7 @@ public final class NDIndexFullSlice {
             long rawMax = Optional.ofNullable(slice.getMax()).orElse(target.size(i));
             max[i] = rawMax < 0 ? Math.floorMod(rawMax, target.get(i)) : rawMax;
             step[i] = Optional.ofNullable(slice.getStep()).orElse(1L);
-            shape[i] = (max[i] - min[i]) / step[i];
+            shape[i] = (long) Math.ceil(((double) (max[i] - min[i])) / step[i]);
             squeezedShape.add(shape[i]);
         } else if (ie instanceof NDIndexAll) {
             padIndexAll(i, target, min, max, step, shape, squeezedShape);

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -171,4 +171,14 @@ public class NDIndexTest {
             Assert.assertEquals(original.get(index), expected);
         }
     }
+
+    @Test
+    public void testSetByFunctionIncrements() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray original = manager.ones(new Shape(1, 5));
+            original.set(new NDIndex(":, 0::2"), array -> array.mul(-1).add(1));
+            NDArray expected = manager.create(new float[][] {{0, 1, 0, 1, 0}});
+            Assert.assertEquals(original, expected);
+        }
+    }
 }


### PR DESCRIPTION
When slicing an NDArray, the result shape should be the ceiling rather than the
floor of the shapes. Or, even if the shape can't be perfectly divided then it
should take the additional value.

fixes #383