### PR TITLE
Docs: Updated 'brew install' command for adoptopenjdk8

### DIFF
--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -24,7 +24,7 @@ For Mac:
 ```bash
 brew tap homebrew/cask-versions
 brew update
-brew cask install adoptopenjdk8
+brew install --cask adoptopenjdk8
 ```
 
 You can also download and install [Oracle JDK](https://www.oracle.com/technetwork/java/javase/overview/index.html)


### PR DESCRIPTION
Updated command in documentation to install adoptopenjdk8 since previous one was deprecated and disabled on the latest brew release.

More info:
https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364