### PR TITLE
Fix recurrent block memory leak and output shape calculation

### DIFF
--- a/api/src/main/java/ai/djl/nn/recurrent/LSTM.java
+++ b/api/src/main/java/ai/djl/nn/recurrent/LSTM.java
@@ -136,9 +136,9 @@ public class LSTM extends RecurrentBlock {
         NDList result = new NDList(head);
         try (NDList parameterList = new NDList()) {
             for (Parameter parameter : parameters.values()) {
-                NDArray array = parameterStore.getValue(parameter, device, training).duplicate();
+                NDArray array = parameterStore.getValue(parameter, device, training).flatten();
                 array.attach(manager);
-                parameterList.add(array.flatten());
+                parameterList.add(array);
             }
             NDArray array = NDArrays.concat(parameterList);
             result.add(array);

--- a/api/src/main/java/ai/djl/nn/recurrent/LSTM.java
+++ b/api/src/main/java/ai/djl/nn/recurrent/LSTM.java
@@ -16,6 +16,7 @@ import ai.djl.Device;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDArrays;
 import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.internal.NDArrayEx;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
@@ -128,27 +129,28 @@ public class LSTM extends RecurrentBlock {
         validateInputSize(inputs);
         long batchSize = inputs.head().getShape().get(0);
         inputs = updateInputLayoutToTNC(inputs);
-        NDArray head = inputs.singletonOrThrow();
+        NDArray head = inputs.head();
+        NDManager manager = head.getManager();
         Device device = head.getDevice();
 
         NDList result = new NDList(head);
         try (NDList parameterList = new NDList()) {
             for (Parameter parameter : parameters.values()) {
-                NDArray array = parameterStore.getValue(parameter, device, training);
+                NDArray array = parameterStore.getValue(parameter, device, training).duplicate();
+                array.attach(manager);
                 parameterList.add(array.flatten());
             }
             NDArray array = NDArrays.concat(parameterList);
             result.add(array);
         }
-        // Adding state and stateCell
-        Shape stateShape = new Shape(numStackedLayers * numDirections, batchSize, stateSize);
+        Shape stateShape = new Shape((long) numStackedLayers * numDirections, batchSize, stateSize);
         if (beginState != null) {
             result.add(beginState);
             result.add(beginStateCell);
         } else {
             // TODO manager creates the NDArray with the wrong device
-            result.add(head.getManager().zeros(stateShape, DataType.FLOAT32, device));
-            result.add(head.getManager().zeros(stateShape, DataType.FLOAT32, device));
+            result.add(manager.zeros(stateShape, DataType.FLOAT32, device));
+            result.add(manager.zeros(stateShape, DataType.FLOAT32, device));
         }
         if (useSequenceLength) {
             result.add(inputs.get(1));

--- a/api/src/main/java/ai/djl/nn/recurrent/RecurrentBlock.java
+++ b/api/src/main/java/ai/djl/nn/recurrent/RecurrentBlock.java
@@ -166,8 +166,8 @@ public abstract class RecurrentBlock extends AbstractBlock {
     public Shape[] getOutputShapes(NDManager manager, Shape[] inputs) {
         // Input shape at this point is NTC. Output Shape should be NTS
         Shape inputShape = inputs[0];
-        Long nShape = inputShape.get(0);
-        Long tShape = inputShape.get(1);
+        long nShape = inputShape.get(0);
+        long tShape = inputShape.get(1);
         Shape nonStateOutputShape = new Shape(nShape, tShape, stateSize * numDirections);
         if (stateOutputs) {
             return new Shape[] {
@@ -233,9 +233,9 @@ public abstract class RecurrentBlock extends AbstractBlock {
         NDList result = new NDList(head);
         try (NDList parameterList = new NDList()) {
             for (Parameter parameter : parameters.values()) {
-                NDArray array = parameterStore.getValue(parameter, device, training).duplicate();
+                NDArray array = parameterStore.getValue(parameter, device, training).flatten();
                 array.attach(manager);
-                parameterList.add(array.flatten());
+                parameterList.add(array);
             }
             NDArray array = NDArrays.concat(parameterList);
             result.add(array);

--- a/api/src/main/java/ai/djl/nn/recurrent/RecurrentBlock.java
+++ b/api/src/main/java/ai/djl/nn/recurrent/RecurrentBlock.java
@@ -175,9 +175,7 @@ public abstract class RecurrentBlock extends AbstractBlock {
                 new Shape((long) numStackedLayers * numDirections, nShape, stateSize)
             };
         }
-        return new Shape[] {
-            nonStateOutputShape
-        };
+        return new Shape[] {nonStateOutputShape};
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Description ##

1. Recurrent block implementation has a memory leak in `opInputs(...)` function, line 240:
`parameterList.add(array.flatten());`
`array.flatten()` is creating new array in model's NDManager, thus this array lives as long as the model. The analogical problem is also present in LSTM block.
2. Recurrent block's `getOutputShapes(...)` function returns incorrect shapes. Block accepts NTC not TNC (which is wrongly assumed as input shape in `getOutputShapes(...)` function).
