### PR TITLE
Fixing typo on doc for NDArray.java

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -2444,7 +2444,7 @@ public interface NDArray extends AutoCloseable {
     NDArray sum();
 
     /**
-     * Returns the minimum of this {@code NDArray} along given axes.
+     * Returns the sum of this {@code NDArray} along given axes.
      *
      * <p>Examples
      *
@@ -2473,7 +2473,7 @@ public interface NDArray extends AutoCloseable {
     }
 
     /**
-     * Returns the minimum of this {@code NDArray} along given axes.
+     * Returns the sum of this {@code NDArray} along given axes.
      *
      * <p>Examples
      *


### PR DESCRIPTION
Replaced `minimum` for `sum` in the `sum` method api documentation.