### PR TITLE
Rename CheckpointsTrainingListener to SaveModelTrainingListener

### DIFF
--- a/api/src/main/java/ai/djl/training/listener/SaveModelTrainingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/SaveModelTrainingListener.java
@@ -20,47 +20,46 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A {@link TrainingListener} that saves a model checkpoint after each epoch. */
-public class CheckpointsTrainingListener extends TrainingListenerAdapter {
+/** A {@link TrainingListener} that saves a model and can save checkpoints. */
+public class SaveModelTrainingListener extends TrainingListenerAdapter {
 
-    private static final Logger logger = LoggerFactory.getLogger(CheckpointsTrainingListener.class);
+    private static final Logger logger = LoggerFactory.getLogger(SaveModelTrainingListener.class);
 
     private String outputDir;
     private String overrideModelName;
     private Consumer<Trainer> onSaveModel;
-    private int step;
+    private int checkpoint;
     private int epoch;
 
     /**
-     * Constructs a {@link CheckpointsTrainingListener} using the model's name.
+     * Constructs a {@link SaveModelTrainingListener} using the model's name.
      *
      * @param outputDir the directory to output the checkpointed models in
      */
-    public CheckpointsTrainingListener(String outputDir) {
+    public SaveModelTrainingListener(String outputDir) {
         this(outputDir, null, -1);
     }
 
     /**
-     * Constructs a {@link CheckpointsTrainingListener}.
+     * Constructs a {@link SaveModelTrainingListener}.
      *
      * @param overrideModelName an override model name to save checkpoints with
      * @param outputDir the directory to output the checkpointed models in
      */
-    public CheckpointsTrainingListener(String outputDir, String overrideModelName) {
+    public SaveModelTrainingListener(String outputDir, String overrideModelName) {
         this(outputDir, overrideModelName, -1);
     }
 
     /**
-     * Constructs a {@link CheckpointsTrainingListener}.
+     * Constructs a {@link SaveModelTrainingListener}.
      *
      * @param overrideModelName an override model name to save checkpoints with
      * @param outputDir the directory to output the checkpointed models in
-     * @param step the spacing between each checkpoint, use -1 to only save model at the end of
-     *     training
+     * @param checkpoint adds a checkpoint every n epochs
      */
-    public CheckpointsTrainingListener(String outputDir, String overrideModelName, int step) {
+    public SaveModelTrainingListener(String outputDir, String overrideModelName, int checkpoint) {
         this.outputDir = outputDir;
-        this.step = step;
+        this.checkpoint = checkpoint;
         if (outputDir == null) {
             throw new IllegalArgumentException(
                     "Can not save checkpoint without specifying an output directory");
@@ -76,7 +75,7 @@ public class CheckpointsTrainingListener extends TrainingListenerAdapter {
             return;
         }
 
-        if (step > 0 && epoch % step == 0) {
+        if (checkpoint > 0 && epoch % checkpoint == 0) {
             // save model at end of each epoch
             saveModel(trainer);
         }
@@ -85,7 +84,7 @@ public class CheckpointsTrainingListener extends TrainingListenerAdapter {
     /** {@inheritDoc} */
     @Override
     public void onTrainingEnd(Trainer trainer) {
-        if (step == -1 || epoch % step != 0) {
+        if (checkpoint == -1 || epoch % checkpoint != 0) {
             saveModel(trainer);
         }
     }
@@ -106,6 +105,24 @@ public class CheckpointsTrainingListener extends TrainingListenerAdapter {
      */
     public void setOverrideModelName(String overrideModelName) {
         this.overrideModelName = overrideModelName;
+    }
+
+    /**
+     * Returns the checkpoint frequency (or -1 for no checkpointing).
+     *
+     * @return the checkpoint frequency (or -1 for no checkpointing)
+     */
+    public int getCheckpoint() {
+        return checkpoint;
+    }
+
+    /**
+     * Sets the checkpoint frequency.
+     *
+     * @param checkpoint how many epochs between checkpoints (or -1 for no checkpoints)
+     */
+    public void setCheckpoint(int checkpoint) {
+        this.checkpoint = checkpoint;
     }
 
     /**

--- a/examples/src/main/java/ai/djl/examples/training/TrainCaptcha.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainCaptcha.java
@@ -31,7 +31,7 @@ import ai.djl.training.dataset.Dataset;
 import ai.djl.training.dataset.Dataset.Usage;
 import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.evaluator.Accuracy;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.SimpleCompositeLoss;
 import ai.djl.training.loss.SoftmaxCrossEntropyLoss;
@@ -88,7 +88,7 @@ public final class TrainCaptcha {
 
     private static DefaultTrainingConfig setupTrainingConfig(Arguments arguments) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/TrainMnist.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainMnist.java
@@ -27,7 +27,7 @@ import ai.djl.training.TrainingResult;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.evaluator.Accuracy;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.Loss;
 import ai.djl.training.util.ProgressBar;
@@ -93,7 +93,7 @@ public final class TrainMnist {
 
     private static DefaultTrainingConfig setupTrainingConfig(Arguments arguments) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/TrainMnistWithLSTM.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainMnistWithLSTM.java
@@ -32,7 +32,7 @@ import ai.djl.training.dataset.Dataset;
 import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.evaluator.Accuracy;
 import ai.djl.training.initializer.XavierInitializer;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.Loss;
 import ai.djl.training.util.ProgressBar;
@@ -102,7 +102,7 @@ public final class TrainMnistWithLSTM {
 
     public static DefaultTrainingConfig setupTrainingConfig(Arguments arguments) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/TrainPikachu.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainPikachu.java
@@ -40,7 +40,7 @@ import ai.djl.training.dataset.Dataset;
 import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.evaluator.BoundingBoxError;
 import ai.djl.training.evaluator.SingleShotDetectionAccuracy;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.SingleShotDetectionLoss;
 import ai.djl.training.util.ProgressBar;
@@ -142,7 +142,7 @@ public final class TrainPikachu {
 
     private static DefaultTrainingConfig setupTrainingConfig(Arguments arguments) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/TrainSentimentAnalysis.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainSentimentAnalysis.java
@@ -50,7 +50,7 @@ import ai.djl.training.TrainingResult;
 import ai.djl.training.dataset.Batch;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.evaluator.Accuracy;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.SoftmaxCrossEntropyLoss;
 import ai.djl.training.util.ProgressBar;
@@ -167,7 +167,7 @@ public final class TrainSentimentAnalysis {
     public static DefaultTrainingConfig setupTrainingConfig(
             Arguments arguments, ModelZooTextEmbedding embedding) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/TrainSeq2Seq.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainSeq2Seq.java
@@ -43,7 +43,7 @@ import ai.djl.training.TrainingResult;
 import ai.djl.training.dataset.Batch;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.evaluator.Accuracy;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.MaskedSoftmaxCrossEntropyLoss;
 import ai.djl.training.util.ProgressBar;
@@ -139,7 +139,7 @@ public final class TrainSeq2Seq {
 
     public static DefaultTrainingConfig setupTrainingConfig(Arguments arguments) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/TrainWithHpo.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainWithHpo.java
@@ -28,7 +28,7 @@ import ai.djl.training.evaluator.Accuracy;
 import ai.djl.training.hyperparameter.EasyHpo;
 import ai.djl.training.hyperparameter.param.HpInt;
 import ai.djl.training.hyperparameter.param.HpSet;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.Loss;
 import ai.djl.training.util.ProgressBar;
@@ -69,7 +69,7 @@ public final class TrainWithHpo {
         @Override
         protected TrainingConfig setupTrainingConfig(HpSet hpVals) {
             String outputDir = arguments.getOutputDir();
-            CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+            SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
             listener.setSaveModelCallback(
                     trainer -> {
                         TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
@@ -40,7 +40,7 @@ import ai.djl.training.TrainingResult;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.evaluator.Accuracy;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.Loss;
 import ai.djl.training.optimizer.Optimizer;
@@ -165,8 +165,7 @@ public final class TrainWithOptimizers {
 
     private static DefaultTrainingConfig setupTrainingConfig(OptimizerArguments arguments) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener =
-                new CheckpointsTrainingListener(outputDir, "resnetv1");
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir, "resnetv1");
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainAmazonReviewRanking.java
+++ b/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainAmazonReviewRanking.java
@@ -43,7 +43,7 @@ import ai.djl.training.Trainer;
 import ai.djl.training.TrainingResult;
 import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.evaluator.Accuracy;
-import ai.djl.training.listener.CheckpointsTrainingListener;
+import ai.djl.training.listener.SaveModelTrainingListener;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.Loss;
 import ai.djl.training.util.ProgressBar;
@@ -196,7 +196,7 @@ public final class TrainAmazonReviewRanking {
 
     private static DefaultTrainingConfig setupTrainingConfig(Arguments arguments) {
         String outputDir = arguments.getOutputDir();
-        CheckpointsTrainingListener listener = new CheckpointsTrainingListener(outputDir);
+        SaveModelTrainingListener listener = new SaveModelTrainingListener(outputDir);
         listener.setSaveModelCallback(
                 trainer -> {
                     TrainingResult result = trainer.getTrainingResult();

--- a/jupyter/rank_classification_using_BERT_on_Amazon_Review.ipynb
+++ b/jupyter/rank_classification_using_BERT_on_Amazon_Review.ipynb
@@ -89,7 +89,7 @@
     "import ai.djl.training.dataset.Batch;\n",
     "import ai.djl.training.dataset.RandomAccessDataset;\n",
     "import ai.djl.training.evaluator.Accuracy;\n",
-    "import ai.djl.training.listener.CheckpointsTrainingListener;\n",
+    "import ai.djl.training.listener.SaveModelTrainingListener;\n",
     "import ai.djl.training.listener.TrainingListener;\n",
     "import ai.djl.training.loss.Loss;\n",
     "import ai.djl.training.util.ProgressBar;\n",


### PR DESCRIPTION
This better clarifies the purpose of the training listener as the default is not
to have checkpoints. Instead, the checkpointing is an optional feature of the
SaveModel listener.