### PR TITLE
fix tflite build flag

### DIFF
--- a/.github/workflows/native_s3_tflite.yml
+++ b/.github/workflows/native_s3_tflite.yml
@@ -28,7 +28,7 @@ jobs:
       - name: build package
         run: |
           cd tensorflow
-          bazel build -c opt //tensorflow/lite/java:tensorflowlitelib tensorflow/lite/delegates/flex:delegate
+          bazel build -c opt //tensorflow/lite/java:tensorflowlitelib  //tensorflow/lite/delegates/flex:delegate
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Accidentally removed the `//` before build flags. 

Now test build pass on Ubuntu 16.04 and Mac OS with tflite 2.4.1

```
INFO: Analyzed 2 targets (242 packages loaded, 19609 targets configured).
INFO: Found 2 targets...
INFO: Elapsed time: 1550.101s, Critical Path: 148.79s
INFO: 8086 processes: 8086 local.
INFO: Build completed successfully, 8444 total actions
```