### PR TITLE
Various fixes and improvements for MultiThreadedBenchmark

### DIFF
--- a/api/src/main/java/ai/djl/training/listener/MemoryTrainingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/MemoryTrainingListener.java
@@ -91,12 +91,12 @@ public class MemoryTrainingListener extends TrainingListenerAdapter {
             MemoryUsage heap = memBean.getHeapMemoryUsage();
             MemoryUsage nonHeap = memBean.getNonHeapMemoryUsage();
 
-            long heapCommitted = heap.getCommitted();
-            long nonHeapCommitted = nonHeap.getCommitted();
+            long heapUsed = heap.getUsed();
+            long nonHeapUsed = nonHeap.getUsed();
             getProcessInfo(metrics);
 
-            metrics.addMetric("Heap", heapCommitted, "bytes");
-            metrics.addMetric("NonHeap", nonHeapCommitted, "bytes");
+            metrics.addMetric("Heap", heapUsed, "bytes");
+            metrics.addMetric("NonHeap", nonHeapUsed, "bytes");
             int gpuCount = Device.getGpuCount();
 
             // CudaUtils.getGpuMemory() will allocates memory on GPUs if CUDA runtime is not

--- a/examples/src/main/java/ai/djl/examples/inference/benchmark/MultithreadedBenchmark.java
+++ b/examples/src/main/java/ai/djl/examples/inference/benchmark/MultithreadedBenchmark.java
@@ -100,7 +100,7 @@ public class MultithreadedBenchmark extends AbstractBenchmark {
 
         model.close();
         if (successThreads != numOfThreads + 1) {
-            logger.error("Only {}/{} threads finished.", successThreads, numOfThreads);
+            logger.error("Only {}/{} threads finished.", successThreads - 1, numOfThreads);
             return null;
         }
 

--- a/examples/src/main/java/ai/djl/examples/inference/benchmark/util/AbstractBenchmark.java
+++ b/examples/src/main/java/ai/djl/examples/inference/benchmark/util/AbstractBenchmark.java
@@ -217,15 +217,23 @@ public abstract class AbstractBenchmark {
                                     postP50, postP90, postP99));
 
                     if (Boolean.getBoolean("collect-memory")) {
+                        float heapBeforeModel = metrics.getMetric("Heap").get(0).getValue().longValue();
+                        float heapBeforeInference = metrics.getMetric("Heap").get(1).getValue().longValue();
                         float heap = metrics.percentile("Heap", 90).getValue().longValue();
                         float nonHeap = metrics.percentile("NonHeap", 90).getValue().longValue();
                         float cpu = metrics.percentile("cpu", 90).getValue().longValue();
+                        float rssBeforeModel = metrics.getMetric("rss").get(0).getValue().longValue();
+                        float rssBeforeInference = metrics.getMetric("rss").get(1).getValue().longValue();
                         float rss = metrics.percentile("rss", 90).getValue().longValue();
 
-                        logger.info(String.format("heap P90: %.3f", heap));
-                        logger.info(String.format("nonHeap P90: %.3f", nonHeap));
-                        logger.info(String.format("cpu P90: %.3f", cpu));
-                        logger.info(String.format("rss P90: %.3f", rss));
+                        logger.info(String.format("heap (base): %.3f MB", heapBeforeModel/(1024*1024)));
+                        logger.info(String.format("heap (model): %.3f MB", (heapBeforeInference - heapBeforeModel)/(1024*1024)));
+                        logger.info(String.format("heap (inference) P90: %.3f MB", (heap - heapBeforeInference)/(1024*1024)));
+                        logger.info(String.format("nonHeap P90: %.3f MB", nonHeap/(1024*1024)));
+                        logger.info(String.format("cpu P90: %.3f %%", cpu));
+                        logger.info(String.format("rss (base): %.3f MB", rssBeforeModel/(1024*1024)));
+                        logger.info(String.format("rss (model): %.3f MB", (rssBeforeInference - rssBeforeModel)/(1024*1024)));
+                        logger.info(String.format("rss (inference) P90: %.3f MB", (rss - rssBeforeInference)/(1024*1024)));
                     }
                 }
                 MemoryTrainingListener.dumpMemoryInfo(metrics, arguments.getOutputDir());

--- a/examples/src/main/java/ai/djl/examples/inference/benchmark/util/AbstractBenchmark.java
+++ b/examples/src/main/java/ai/djl/examples/inference/benchmark/util/AbstractBenchmark.java
@@ -217,23 +217,43 @@ public abstract class AbstractBenchmark {
                                     postP50, postP90, postP99));
 
                     if (Boolean.getBoolean("collect-memory")) {
-                        float heapBeforeModel = metrics.getMetric("Heap").get(0).getValue().longValue();
-                        float heapBeforeInference = metrics.getMetric("Heap").get(1).getValue().longValue();
+                        float heapBeforeModel =
+                                metrics.getMetric("Heap").get(0).getValue().longValue();
+                        float heapBeforeInference =
+                                metrics.getMetric("Heap").get(1).getValue().longValue();
                         float heap = metrics.percentile("Heap", 90).getValue().longValue();
                         float nonHeap = metrics.percentile("NonHeap", 90).getValue().longValue();
                         float cpu = metrics.percentile("cpu", 90).getValue().longValue();
-                        float rssBeforeModel = metrics.getMetric("rss").get(0).getValue().longValue();
-                        float rssBeforeInference = metrics.getMetric("rss").get(1).getValue().longValue();
+                        float rssBeforeModel =
+                                metrics.getMetric("rss").get(0).getValue().longValue();
+                        float rssBeforeInference =
+                                metrics.getMetric("rss").get(1).getValue().longValue();
                         float rss = metrics.percentile("rss", 90).getValue().longValue();
 
-                        logger.info(String.format("heap (base): %.3f MB", heapBeforeModel/(1024*1024)));
-                        logger.info(String.format("heap (model): %.3f MB", (heapBeforeInference - heapBeforeModel)/(1024*1024)));
-                        logger.info(String.format("heap (inference) P90: %.3f MB", (heap - heapBeforeInference)/(1024*1024)));
-                        logger.info(String.format("nonHeap P90: %.3f MB", nonHeap/(1024*1024)));
+                        logger.info(
+                                String.format(
+                                        "heap (base): %.3f MB", heapBeforeModel / (1024 * 1024)));
+                        logger.info(
+                                String.format(
+                                        "heap (model): %.3f MB",
+                                        (heapBeforeInference - heapBeforeModel) / (1024 * 1024)));
+                        logger.info(
+                                String.format(
+                                        "heap (inference) P90: %.3f MB",
+                                        (heap - heapBeforeInference) / (1024 * 1024)));
+                        logger.info(String.format("nonHeap P90: %.3f MB", nonHeap / (1024 * 1024)));
                         logger.info(String.format("cpu P90: %.3f %%", cpu));
-                        logger.info(String.format("rss (base): %.3f MB", rssBeforeModel/(1024*1024)));
-                        logger.info(String.format("rss (model): %.3f MB", (rssBeforeInference - rssBeforeModel)/(1024*1024)));
-                        logger.info(String.format("rss (inference) P90: %.3f MB", (rss - rssBeforeInference)/(1024*1024)));
+                        logger.info(
+                                String.format(
+                                        "rss (base): %.3f MB", rssBeforeModel / (1024 * 1024)));
+                        logger.info(
+                                String.format(
+                                        "rss (model): %.3f MB",
+                                        (rssBeforeInference - rssBeforeModel) / (1024 * 1024)));
+                        logger.info(
+                                String.format(
+                                        "rss (inference) P90: %.3f MB",
+                                        (rss - rssBeforeInference) / (1024 * 1024)));
                     }
                 }
                 MemoryTrainingListener.dumpMemoryInfo(metrics, arguments.getOutputDir());


### PR DESCRIPTION
* Collects used memory instead of committed for the JVM. The committed memory amount is [guaranteed](https://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html) to be available to the JVM and not the currently used amount.
* Runs memory collection on a separate thread. Memory collection can be slow compared to inference which significantly affects the throughput measurement of the first worker thread.
* Collects memory before and after model loading to print separate base, model, and inference memory usage.
