### PR TITLE
Update BERT example

### DIFF
--- a/examples/src/main/java/ai/djl/examples/training/TrainCaptcha.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainCaptcha.java
@@ -55,7 +55,7 @@ public final class TrainCaptcha {
     }
 
     public static TrainingResult runExample(String[] args) throws IOException, TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainMnist.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainMnist.java
@@ -50,7 +50,7 @@ public final class TrainMnist {
     }
 
     public static TrainingResult runExample(String[] args) throws IOException, TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainMnistWithLSTM.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainMnistWithLSTM.java
@@ -48,7 +48,7 @@ public final class TrainMnistWithLSTM {
     }
 
     public static TrainingResult runExample(String[] args) throws IOException, TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainPikachu.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainPikachu.java
@@ -71,7 +71,7 @@ public final class TrainPikachu {
     }
 
     public static TrainingResult runExample(String[] args) throws IOException, TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainSentimentAnalysis.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainSentimentAnalysis.java
@@ -86,7 +86,7 @@ public final class TrainSentimentAnalysis {
     public static TrainingResult runExample(String[] args)
             throws IOException, ModelNotFoundException, MalformedModelException,
                     TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainSeq2Seq.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainSeq2Seq.java
@@ -64,7 +64,7 @@ public final class TrainSeq2Seq {
     }
 
     public static TrainingResult runExample(String[] args) throws IOException, TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainTicTacToe.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainTicTacToe.java
@@ -57,7 +57,7 @@ public final class TrainTicTacToe {
     }
 
     public static TrainingResult runExample(String[] args) throws IOException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainWithHpo.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainWithHpo.java
@@ -50,7 +50,7 @@ public final class TrainWithHpo {
     }
 
     public static TrainingResult runExample(String[] args) throws IOException, TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
@@ -52,7 +52,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -71,10 +70,8 @@ public final class TrainWithOptimizers {
     public static TrainingResult runExample(String[] args)
             throws IOException, ParseException, ModelNotFoundException, MalformedModelException,
                     TranslateException {
-        Options options = OptimizerArguments.getOptions();
-        DefaultParser parser = new DefaultParser();
-        CommandLine cmd = parser.parse(options, args, null, false);
-        OptimizerArguments arguments = new OptimizerArguments(cmd);
+        OptimizerArguments arguments =
+                (OptimizerArguments) new OptimizerArguments().parseArgs(args);
 
         try (Model model = getModel(arguments)) {
             // get training dataset
@@ -240,9 +237,11 @@ public final class TrainWithOptimizers {
 
         private String optimizer;
 
-        public OptimizerArguments(CommandLine cmd) {
-            super(cmd);
+        public OptimizerArguments() {}
 
+        @Override
+        protected void setCmd(CommandLine cmd) {
+            super.setCmd(cmd);
             if (cmd.hasOption("optimizer")) {
                 optimizer = cmd.getOptionValue("optimizer");
             } else {
@@ -250,8 +249,9 @@ public final class TrainWithOptimizers {
             }
         }
 
-        public static Options getOptions() {
-            Options options = Arguments.getOptions();
+        @Override
+        public Options getOptions() {
+            Options options = super.getOptions();
             options.addOption(
                     Option.builder("z")
                             .longOpt("optimizer")

--- a/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainAmazonReviewRanking.java
+++ b/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainAmazonReviewRanking.java
@@ -66,7 +66,7 @@ public final class TrainAmazonReviewRanking {
 
     public static TrainingResult runExample(String[] args)
             throws IOException, TranslateException, ModelException, URISyntaxException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainResnetWithCifar10.java
+++ b/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainResnetWithCifar10.java
@@ -77,7 +77,7 @@ public final class TrainResnetWithCifar10 {
 
     public static TrainingResult runExample(String[] args)
             throws IOException, ModelException, TranslateException {
-        Arguments arguments = Arguments.parseArgs(args);
+        Arguments arguments = new Arguments().parseArgs(args);
         if (arguments == null) {
             return null;
         }

--- a/examples/src/main/java/ai/djl/examples/training/util/Arguments.java
+++ b/examples/src/main/java/ai/djl/examples/training/util/Arguments.java
@@ -26,23 +26,28 @@ import org.apache.commons.cli.ParseException;
 
 public class Arguments {
 
-    private int epoch;
-    private int batchSize;
-    private int maxGpus;
-    private boolean isSymbolic;
-    private boolean preTrained;
-    private String outputDir;
-    private long limit;
-    private String modelDir;
-    private Map<String, String> criteria;
+    protected int epoch;
+    protected int batchSize;
+    protected int maxGpus;
+    protected boolean isSymbolic;
+    protected boolean preTrained;
+    protected String outputDir;
+    protected long limit;
+    protected String modelDir;
+    protected Map<String, String> criteria;
 
-    public Arguments(CommandLine cmd) {
+    protected void initialize() {
+        epoch = 2;
+        maxGpus = Device.getGpuCount();
+        outputDir = "build/model";
+        limit = Long.MAX_VALUE;
+        modelDir = null;
+    }
+
+    protected void setCmd(CommandLine cmd) {
         if (cmd.hasOption("epoch")) {
             epoch = Integer.parseInt(cmd.getOptionValue("epoch"));
-        } else {
-            epoch = 2;
         }
-        maxGpus = Device.getGpuCount();
         if (cmd.hasOption("max-gpus")) {
             maxGpus = Math.min(Integer.parseInt(cmd.getOptionValue("max-gpus")), maxGpus);
         }
@@ -56,18 +61,12 @@ public class Arguments {
 
         if (cmd.hasOption("output-dir")) {
             outputDir = cmd.getOptionValue("output-dir");
-        } else {
-            outputDir = "build/model";
         }
         if (cmd.hasOption("max-batches")) {
             limit = Long.parseLong(cmd.getOptionValue("max-batches")) * batchSize;
-        } else {
-            limit = Long.MAX_VALUE;
         }
         if (cmd.hasOption("model-dir")) {
             modelDir = cmd.getOptionValue("model-dir");
-        } else {
-            modelDir = null;
         }
         if (cmd.hasOption("criteria")) {
             Type type = new TypeToken<Map<String, Object>>() {}.getType();
@@ -75,8 +74,9 @@ public class Arguments {
         }
     }
 
-    public static Arguments parseArgs(String[] args) {
-        Options options = Arguments.getOptions();
+    public Arguments parseArgs(String[] args) {
+        initialize();
+        Options options = getOptions();
         try {
             DefaultParser parser = new DefaultParser();
             CommandLine cmd = parser.parse(options, args, null, false);
@@ -84,14 +84,15 @@ public class Arguments {
                 printHelp("./gradlew run --args='[OPTIONS]'", options);
                 return null;
             }
-            return new Arguments(cmd);
+            setCmd(cmd);
+            return this;
         } catch (ParseException e) {
             printHelp("./gradlew run --args='[OPTIONS]'", options);
         }
         return null;
     }
 
-    public static Options getOptions() {
+    public Options getOptions() {
         Options options = new Options();
         options.addOption(
                 Option.builder("h").longOpt("help").hasArg(false).desc("Print this help.").build());
@@ -196,7 +197,7 @@ public class Arguments {
         return criteria;
     }
 
-    private static void printHelp(String msg, Options options) {
+    private void printHelp(String msg, Options options) {
         HelpFormatter formatter = new HelpFormatter();
         formatter.setLeftPadding(1);
         formatter.setWidth(120);

--- a/examples/src/test/java/ai/djl/examples/training/TrainBertTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainBertTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.examples.training;
+
+import org.testng.annotations.Test;
+
+public class TrainBertTest {
+
+    @Test
+    public void testTrainBert() {
+        String[] args = new String[] {"-g", "1", "-m", "1", "-e", "1"};
+        TrainBertOnCode.runExample(args);
+    }
+}


### PR DESCRIPTION
- Add TrainBertTest
- Add try-with-resources to model and trainer
- Add progress when creating batches
- Use arguments in BERT
- Add missing training listener notifications

Also updated:
- Make example train Arguments class inheritable to update both default values
and number of options. Before, defaults were not modifiable and it was more
difficult to use derivative arguments.