### PR TITLE
Create ObjectDetectionDataset

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/output/Rectangle.java
+++ b/api/src/main/java/ai/djl/modality/cv/output/Rectangle.java
@@ -16,6 +16,10 @@ package ai.djl.modality.cv.output;
  * A {@code Rectangle} specifies an area in a coordinate space that is enclosed by the {@code
  * Rectangle} object's upper-left point {@link Point} in the coordinate space, its width, and its
  * height.
+ *
+ * <p>The rectangle coordinates are usually from 0-1 and are ratios of the image size. For example,
+ * if you have an image width of 400 pixels and the rectangle starts at 100 pixels, you would use
+ * .25.
  */
 public class Rectangle implements BoundingBox {
 
@@ -28,22 +32,32 @@ public class Rectangle implements BoundingBox {
      * Constructs a new {@code Rectangle} whose upper-left corner is specified as {@code (x,y)} and
      * whose width and height are specified by the arguments of the same name.
      *
-     * @param x the specified X coordinate
-     * @param y the specified Y coordinate
-     * @param width the width of the {@code Rectangle}
-     * @param height the height of the {@code Rectangle}
+     * @param x the specified X coordinate (0-1)
+     * @param y the specified Y coordinate (0-1)
+     * @param width the width of the {@code Rectangle} (0-1)
+     * @param height the height of the {@code Rectangle} (0-1)
      */
     public Rectangle(double x, double y, double width, double height) {
         this(new Point(x, y), width, height);
     }
 
     /**
+     * Constructs a new {@code Rectangle} with the upperLeft and lowerRight coordinates.
+     *
+     * @param upperLeft the upper left coordinate (0-1)
+     * @param lowerRight the upper left coordinate (0-1)
+     */
+    public Rectangle(Point upperLeft, Point lowerRight) {
+        this(upperLeft, lowerRight.getX(), lowerRight.getY());
+    }
+
+    /**
      * Constructs a new {@code Rectangle} whose upper-left corner is specified as coordinate {@code
      * point} and whose width and height are specified by the arguments of the same name.
      *
-     * @param point the upper-left corner of the coordinate
-     * @param width the width of the {@code Rectangle}
-     * @param height the height of the {@code Rectangle}
+     * @param point the upper-left corner of the coordinate (0-1)
+     * @param width the width of the {@code Rectangle} (0-1)
+     * @param height the height of the {@code Rectangle} (0-1)
      */
     public Rectangle(Point point, double width, double height) {
         this.point = point;
@@ -121,7 +135,7 @@ public class Rectangle implements BoundingBox {
     /**
      * Returns the left x-coordinate of the Rectangle.
      *
-     * @return the left x-coordinate of the Rectangle
+     * @return the left x-coordinate of the Rectangle (0-1)
      */
     public double getX() {
         return point.getX();
@@ -130,7 +144,7 @@ public class Rectangle implements BoundingBox {
     /**
      * Returns the top y-coordinate of the Rectangle.
      *
-     * @return the top y-coordinate of the Rectangle
+     * @return the top y-coordinate of the Rectangle (0-1)
      */
     public double getY() {
         return point.getY();
@@ -139,7 +153,7 @@ public class Rectangle implements BoundingBox {
     /**
      * Returns the width of the Rectangle.
      *
-     * @return the width of the Rectangle
+     * @return the width of the Rectangle (0-1)
      */
     public double getWidth() {
         return width;
@@ -148,7 +162,7 @@ public class Rectangle implements BoundingBox {
     /**
      * Returns the height of the Rectangle.
      *
-     * @return the height of the Rectangle
+     * @return the height of the Rectangle (0-1)
      */
     public double getHeight() {
         return height;

--- a/basicdataset/src/main/java/ai/djl/basicdataset/cv/ImageDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/cv/ImageDataset.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.cv;
+
+import ai.djl.basicdataset.cv.classification.ImageClassificationDataset;
+import ai.djl.modality.cv.Image;
+import ai.djl.modality.cv.util.NDImageUtils;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDManager;
+import ai.djl.training.dataset.RandomAccessDataset;
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A helper to create a {@link ai.djl.training.dataset.Dataset} where the data contains a single
+ * image.
+ */
+public abstract class ImageDataset extends RandomAccessDataset {
+    protected Image.Flag flag;
+
+    /**
+     * Creates a new instance of {@link RandomAccessDataset} with the given necessary
+     * configurations.
+     *
+     * @param builder a builder with the necessary configurations
+     */
+    public ImageDataset(BaseBuilder<?> builder) {
+        super(builder);
+        this.flag = builder.flag;
+    }
+
+    protected NDArray getRecordImage(NDManager manager, long index) throws IOException {
+        NDArray image = getImage(index).toNDArray(manager, flag);
+
+        // Resize the image if the image size is fixed
+        Optional<Integer> width = getImageWidth();
+        Optional<Integer> height = getImageHeight();
+        if (width.isPresent() && height.isPresent()) {
+            image = NDImageUtils.resize(image, width.get(), height.get());
+        }
+        return image;
+    }
+
+    /**
+     * Returns the image at the given index in the dataset.
+     *
+     * @param index the index (if the dataset is a list of data items)
+     * @return the image
+     * @throws IOException if the image could not be loaded
+     */
+    protected abstract Image getImage(long index) throws IOException;
+
+    /**
+     * Returns the number of channels in the images in the dataset.
+     *
+     * <p>For example, RGB would be 3 channels while grayscale only uses 1 channel.
+     *
+     * @return the number of channels in the images in the dataset
+     */
+    public int getImageChannels() {
+        return flag.numChannels();
+    }
+
+    /**
+     * Returns the width of the images in the dataset.
+     *
+     * @return the width of the images in the dataset
+     */
+    public abstract Optional<Integer> getImageWidth();
+
+    /**
+     * Returns the height of the images in the dataset.
+     *
+     * @return the height of the images in the dataset
+     */
+    public abstract Optional<Integer> getImageHeight();
+
+    /**
+     * Used to build an {@link ImageClassificationDataset}.
+     *
+     * @param <T> the builder type
+     */
+    @SuppressWarnings("rawtypes")
+    public abstract static class BaseBuilder<T extends BaseBuilder<T>>
+            extends RandomAccessDataset.BaseBuilder<T> {
+
+        Image.Flag flag;
+
+        protected BaseBuilder() {
+            flag = Image.Flag.COLOR;
+        }
+
+        /**
+         * Sets the optional color mode flag.
+         *
+         * @param flag the color mode flag
+         * @return this builder
+         */
+        public T optFlag(Image.Flag flag) {
+            this.flag = flag;
+            return self();
+        }
+    }
+}

--- a/basicdataset/src/main/java/ai/djl/basicdataset/cv/ObjectDetectionDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/cv/ObjectDetectionDataset.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.cv;
+
+import ai.djl.modality.cv.output.Rectangle;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.training.dataset.Record;
+import ai.djl.util.Pair;
+import ai.djl.util.PairList;
+import java.io.IOException;
+
+/**
+ * A helper to create {@link ai.djl.training.dataset.Dataset}s for {@link
+ * ai.djl.Application.CV#OBJECT_DETECTION}.
+ */
+public abstract class ObjectDetectionDataset extends ImageDataset {
+
+    /**
+     * Creates a new instance of {@link ObjectDetectionDataset} with the given necessary
+     * configurations.
+     *
+     * @param builder a builder with the necessary configurations
+     */
+    public ObjectDetectionDataset(ImageDataset.BaseBuilder<?> builder) {
+        super(builder);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Record get(NDManager manager, long index) throws IOException {
+        NDList data = new NDList(getRecordImage(manager, index));
+
+        PairList<Long, Rectangle> objects = getObjects(index);
+        float[][] labelsSplit = new float[objects.size()][5];
+        for (int i = 0; i < objects.size(); i++) {
+            Pair<Long, Rectangle> obj = objects.get(i);
+            labelsSplit[i][0] = obj.getKey();
+
+            Rectangle location = obj.getValue();
+            labelsSplit[i][1] = (float) location.getX();
+            labelsSplit[i][2] = (float) location.getY();
+            labelsSplit[i][3] = (float) location.getWidth();
+            labelsSplit[i][4] = (float) location.getHeight();
+        }
+        NDList labels = new NDList(manager.create(labelsSplit));
+        return new Record(data, labels);
+    }
+
+    /**
+     * Returns the list of objects in the image at the given index.
+     *
+     * @param index the index (if the dataset is a list of data items)
+     * @return the list of objects in the image. The long is the class number of the index into the
+     *     list of classes of the desired class name. The rectangle is the location of the object
+     *     inside the image.
+     * @throws IOException if the data could not be loaded
+     */
+    public abstract PairList<Long, Rectangle> getObjects(long index) throws IOException;
+}


### PR DESCRIPTION
This dataset simplifies the creation of new object detection datasets by
presenting a clearer and more standard class to extend.

This PR first creates an ImageDataset class that is the parent class of both the
ImageClassificationDataset and this ObjectDetectionDataset.

The ObjectDetectionDataset is then used as the new parent for the BananaDataset,
PikachuDataset, and CocoDetection dataset. They are all modified to use it.

In addition, some additional documentation is added to Rectangle to document
that it usually has coordinates from 0 to 1.