### PR TITLE
Rename CheckpointsTrainingListener to SaveModelTrainingListener

### DIFF
--- a/jupyter/rank_classification_using_BERT_on_Amazon_Review.ipynb
+++ b/jupyter/rank_classification_using_BERT_on_Amazon_Review.ipynb
@@ -321,7 +321,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CheckpointsTrainingListener listener = new CheckpointsTrainingListener(\"build/model\");\n",
+    "SaveModelTrainingListener listener = new SaveModelTrainingListener(\"build/model\");\n",
     "        listener.setSaveModelCallback(\n",
     "            trainer -> {\n",
     "                TrainingResult result = trainer.getTrainingResult();\n",


### PR DESCRIPTION
## Description ##
The Notebook was broken due to missing class name. The class name was changed [PR#573](https://github.com/awslabs/djl/pull/573) 

