### PR TITLE
DJL BlockFactory

### DIFF
--- a/api/src/main/java/ai/djl/engine/Engine.java
+++ b/api/src/main/java/ai/djl/engine/Engine.java
@@ -15,6 +15,7 @@ package ai.djl.engine;
 import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 import ai.djl.training.LocalParameterServer;
 import ai.djl.training.ParameterServer;
@@ -189,6 +190,14 @@ public abstract class Engine {
         }
         return defaultDevice;
     }
+
+    /**
+     * Construct an empty SymbolBlock for loading.
+     *
+     * @param manager the manager to manage parameters
+     * @return Empty {@link SymbolBlock} for static graph
+     */
+    public abstract SymbolBlock newSymbolBlock(NDManager manager);
 
     /**
      * Constructs a new model.

--- a/api/src/main/java/ai/djl/nn/BlockFactory.java
+++ b/api/src/main/java/ai/djl/nn/BlockFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.nn;
+
+import ai.djl.ndarray.NDManager;
+import ai.djl.repository.zoo.ModelZoo;
+import java.io.Serializable;
+
+/**
+ * Block factory is a component to make standard for block creating and saving procedure. Block
+ * factory design is intended to bypass the serialization of the blocks. This class can be used by
+ * {@link ModelZoo} or DJL Serving to recover the block to its uninitialized states. User should
+ * combine this method with the block.loadParameter to get the block with all parameters.
+ */
+public interface BlockFactory extends Serializable {
+
+    /**
+     * Constructs the uninitialized block.
+     *
+     * @param manager the manager to assign to block
+     * @return the uninitialized block
+     */
+    Block newBlock(NDManager manager);
+}

--- a/api/src/main/java/ai/djl/nn/SymbolBlock.java
+++ b/api/src/main/java/ai/djl/nn/SymbolBlock.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.nn;
 
+import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.util.PairList;
 
@@ -20,6 +21,16 @@ import ai.djl.util.PairList;
  * the engine in its native format.
  */
 public interface SymbolBlock extends Block {
+
+    /**
+     * Creates an empty SymbolBlock instance.
+     *
+     * @param manager the manager to be applied in the SymbolBlock
+     * @return a new Model instance
+     */
+    static SymbolBlock newInstance(NDManager manager) {
+        return manager.getEngine().newSymbolBlock(manager);
+    }
 
     /** Removes the last block in the symbolic graph. */
     default void removeLastBlock() {

--- a/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrEngine.java
+++ b/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrEngine.java
@@ -19,6 +19,7 @@ import ai.djl.dlr.jni.LibUtils;
 import ai.djl.engine.Engine;
 import ai.djl.engine.EngineException;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 
 /**
@@ -78,6 +79,12 @@ public final class DlrEngine extends Engine {
     @Override
     public boolean hasCapability(String capability) {
         return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SymbolBlock newSymbolBlock(NDManager manager) {
+        throw new UnsupportedOperationException("DLR does not support empty SymbolBlock");
     }
 
     /** {@inheritDoc} */

--- a/integration/src/main/java/ai/djl/integration/tests/nn/BlockFactoryTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/nn/BlockFactoryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.integration.tests.nn;
+
+import ai.djl.Application;
+import ai.djl.MalformedModelException;
+import ai.djl.Model;
+import ai.djl.engine.Engine;
+import ai.djl.inference.Predictor;
+import ai.djl.modality.Classifications;
+import ai.djl.modality.cv.Image;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.nn.Block;
+import ai.djl.nn.BlockFactory;
+import ai.djl.nn.Blocks;
+import ai.djl.nn.SequentialBlock;
+import ai.djl.nn.SymbolBlock;
+import ai.djl.nn.core.Linear;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ModelNotFoundException;
+import ai.djl.repository.zoo.ModelZoo;
+import ai.djl.testing.Assertions;
+import ai.djl.training.ParameterStore;
+import ai.djl.training.util.ProgressBar;
+import ai.djl.translate.NoopTranslator;
+import ai.djl.translate.TranslateException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import org.testng.annotations.Test;
+
+public class BlockFactoryTest {
+
+    @Test
+    public void testBlockLoadingSaving()
+            throws IOException, ModelNotFoundException, MalformedModelException,
+                    TranslateException {
+        TestBlockFactory factory = new TestBlockFactory();
+        Model model = factory.getRemoveLastBlockModel();
+        try (NDManager manager = NDManager.newBaseManager()) {
+            Block block = model.getBlock();
+            block.forward(
+                    new ParameterStore(manager, true),
+                    new NDList(manager.ones(new Shape(1, 3, 32, 32))),
+                    true);
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            block.saveParameters(new DataOutputStream(os));
+            ByteArrayInputStream bis = new ByteArrayInputStream(os.toByteArray());
+            Block newBlock = factory.newBlock(manager);
+            newBlock.loadParameters(manager, new DataInputStream(bis));
+            try (Model test = Model.newInstance("test")) {
+                test.setBlock(newBlock);
+                try (Predictor<NDList, NDList> predOrigin =
+                                model.newPredictor(new NoopTranslator());
+                        Predictor<NDList, NDList> predDest =
+                                test.newPredictor(new NoopTranslator())) {
+                    NDList input = new NDList(manager.ones(new Shape(1, 3, 32, 32)));
+                    NDList originOut = predOrigin.predict(input);
+                    NDList destOut = predDest.predict(input);
+                    Assertions.assertAlmostEquals(originOut, destOut);
+                }
+            }
+        }
+    }
+
+    static class TestBlockFactory implements BlockFactory {
+
+        private static final long serialVersionUID = 1234567L;
+
+        @Override
+        public Block newBlock(NDManager manager) {
+            SequentialBlock newBlock = new SequentialBlock();
+            newBlock.add(SymbolBlock.newInstance(manager));
+            newBlock.add(Blocks.batchFlattenBlock());
+            newBlock.add(Linear.builder().setUnits(10).build());
+            return newBlock;
+        }
+
+        public Model getRemoveLastBlockModel()
+                throws MalformedModelException, ModelNotFoundException, IOException {
+            String name = Engine.getInstance().getEngineName();
+            Criteria.Builder<Image, Classifications> builder =
+                    Criteria.builder()
+                            .optApplication(Application.CV.IMAGE_CLASSIFICATION)
+                            .setTypes(Image.class, Classifications.class)
+                            .optProgress(new ProgressBar())
+                            .optArtifactId("resnet")
+                            .optEngine(name)
+                            .optGroupId("ai.djl." + name.toLowerCase())
+                            .optFilter("layers", "50");
+            Model model = ModelZoo.loadModel(builder.build());
+            SequentialBlock newBlock = new SequentialBlock();
+            SymbolBlock block = (SymbolBlock) model.getBlock();
+            block.removeLastBlock();
+            newBlock.add(block);
+            newBlock.add(Blocks.batchFlattenBlock());
+            newBlock.add(Linear.builder().setUnits(10).build());
+            model.setBlock(newBlock);
+            return model;
+        }
+    }
+}

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
@@ -19,6 +19,7 @@ import ai.djl.engine.EngineException;
 import ai.djl.mxnet.jna.JnaUtils;
 import ai.djl.mxnet.jna.LibUtils;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 import ai.djl.training.LocalParameterServer;
 import ai.djl.training.ParameterServer;
@@ -99,6 +100,12 @@ public final class MxEngine extends Engine {
     @Override
     public boolean hasCapability(String capability) {
         return JnaUtils.getFeatures().contains(capability);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SymbolBlock newSymbolBlock(NDManager manager) {
+        return new MxSymbolBlock(manager);
     }
 
     /** {@inheritDoc} */

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxSymbolBlock.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxSymbolBlock.java
@@ -260,10 +260,8 @@ public class MxSymbolBlock extends AbstractSymbolBlock {
         for (String name : inputNames) {
             os.writeUTF(name);
         }
-        for (Parameter parameter : parameters.values()) {
-            if (!inputNames.contains(parameter.getName())) {
-                parameter.save(os);
-            }
+        for (Parameter parameter : mxNetParams) {
+            parameter.save(os);
         }
     }
 
@@ -286,21 +284,20 @@ public class MxSymbolBlock extends AbstractSymbolBlock {
                 throw new MalformedModelException("InputStream ends at symbol loading!");
             }
             // init block only if it is not set
-            if (symbol == null) {
-                symbol =
-                        Symbol.loadJson(
-                                (MxNDManager) manager, new String(bytes, StandardCharsets.UTF_8));
-                initBlock();
-            }
+            symbol =
+                    Symbol.loadJson(
+                            (MxNDManager) manager, new String(bytes, StandardCharsets.UTF_8));
+            initBlock();
         }
         int size = is.readInt();
         for (int i = 0; i < size; ++i) {
             inputNames.add(is.readUTF());
         }
 
-        for (Parameter parameter : parameters.values()) {
+        for (Parameter parameter : mxNetParams) {
             parameter.load(this.manager, is);
         }
+        setInputNames(inputNames);
     }
 
     private void initBlock() {

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtEngine.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtEngine.java
@@ -17,6 +17,7 @@ import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 import ai.onnxruntime.OrtEnvironment;
 
@@ -83,6 +84,12 @@ public final class OrtEngine extends Engine {
     @Override
     public Model newModel(String name, Device device) {
         return new OrtModel(name, newBaseManager(device), env);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SymbolBlock newSymbolBlock(NDManager manager) {
+        throw new UnsupportedOperationException("ONNXRuntime does not support empty SymbolBlock");
     }
 
     /** {@inheritDoc} */

--- a/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpEngine.java
+++ b/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpEngine.java
@@ -16,6 +16,7 @@ import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.paddlepaddle.jni.JniUtils;
 import ai.djl.paddlepaddle.jni.LibUtils;
 import ai.djl.training.GradientCollector;
@@ -83,6 +84,12 @@ public final class PpEngine extends Engine {
     @Override
     public Model newModel(String name, Device device) {
         return new PpModel(name, newBaseManager(device));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SymbolBlock newSymbolBlock(NDManager manager) {
+        throw new UnsupportedOperationException("PaddlePaddle does not support empty SymbolBlock");
     }
 
     /** {@inheritDoc} */

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
@@ -17,6 +17,7 @@ import ai.djl.Model;
 import ai.djl.engine.Engine;
 import ai.djl.engine.EngineException;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.pytorch.jni.JniUtils;
 import ai.djl.pytorch.jni.LibUtils;
 import ai.djl.training.GradientCollector;
@@ -79,6 +80,12 @@ public final class PtEngine extends Engine {
     @Override
     public boolean hasCapability(String capability) {
         return JniUtils.getFeatures().contains(capability);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SymbolBlock newSymbolBlock(NDManager manager) {
+        return new PtSymbolBlock((PtNDManager) manager);
     }
 
     /** {@inheritDoc} */

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
@@ -18,6 +18,7 @@ import ai.djl.engine.Engine;
 import ai.djl.engine.EngineException;
 import ai.djl.engine.StandardCapabilities;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 import ai.djl.util.RandomUtils;
 import org.tensorflow.EagerSession;
@@ -54,6 +55,12 @@ public final class TfEngine extends Engine {
     @Override
     public Model newModel(String name, Device device) {
         return new TfModel(name, device);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SymbolBlock newSymbolBlock(NDManager manager) {
+        throw new UnsupportedOperationException("TensorFlow does not support empty SymbolBlock");
     }
 
     /** {@inheritDoc} */

--- a/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteEngine.java
+++ b/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteEngine.java
@@ -17,6 +17,7 @@ import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 
 /**
@@ -81,6 +82,12 @@ public final class TfLiteEngine extends Engine {
     public Model newModel(String name, Device device) {
         // We need pass TfLiteManager explicitly
         return new TfLiteModel(name, newBaseManager(device));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SymbolBlock newSymbolBlock(NDManager manager) {
+        throw new UnsupportedOperationException("TFLite does not support empty SymbolBlock");
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Description ##

The block factory is a class that provides easy access to recover DJL based model for inference with DJLServing. It contains a single function `getBlock()`  and essentially just recover the block.

Apart from that, there is a new `SymbolBlock.newInstance()` method that only create a empty SymbolBlock holder. It can now be used in PyTorch and MXNet to recover the Symbolic model information from combined params file. In this case, we no longer needs to load the SymbolBlock from the model, instead, everything is loaded from 1 file.