### PR TITLE
Non zero operator for PyTorch

### DIFF
--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -1367,7 +1367,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray nonzero() {
-        throw new UnsupportedOperationException("Not implemented");
+        return JniUtils.nonZeros(this);
     }
 
     /** {@inheritDoc} */

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -1496,4 +1496,12 @@ public final class JniUtils {
                 ndArray.getManager(),
                 PyTorchLibrary.LIB.torchNorm(ndArray.getHandle(), ord, longAxes, keepDims));
     }
+
+    public static PtNDArray nonZeros(PtNDArray ndArray) {
+        if (ndArray.isScalar()) {
+            ndArray = (PtNDArray) ndArray.reshape(-1);
+        }
+        return new PtNDArray(
+                ndArray.getManager(), PyTorchLibrary.LIB.torchNonZeros(ndArray.getHandle()));
+    }
 }

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -534,4 +534,6 @@ final class PyTorchLibrary {
             float momentum);
 
     native long torchNorm(long handle, int ord, long[] axis, boolean keepDims);
+
+    native long torchNonZeros(long handle);
 }

--- a/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_isjm.cc
+++ b/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_isjm.cc
@@ -159,3 +159,13 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchRepeatInterl
   return reinterpret_cast<uintptr_t>(result_ptr);
   API_END_RETURN()
 }
+
+JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchNonZeros(
+    JNIEnv* env, jobject jthis, jlong jhandle) {
+  API_BEGIN()
+  const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
+  const torch::Tensor* result_ptr = new torch::Tensor(tensor_ptr->nonzero());
+
+  return reinterpret_cast<uintptr_t>(result_ptr);
+  API_END_RETURN()
+}


### PR DESCRIPTION
Added nonzero operator for PyTorch. Added a Scalar check in JniUtils as PyTorch behaves differently in comparison to MXNet when passed a scalar value for nonzero operator.
