### PR TITLE
stopGradient on PyTorch

### DIFF
--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -202,7 +202,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public NDArray stopGradient() {
-        throw new UnsupportedOperationException("Not supported");
+        return JniUtils.detachGradient(this);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
One of the enhancements in 0.10.0 was "Adds the NDArray stopGradient and scaleGradient functions (#548)".
It works great on MXNet. Thanks for the feature. 

To benefit from one of the 0.10.0 key features "Upgrades PyTorch to 1.7.1" I wired up the stopGradient for PyTorch which makes up the line of change in this pull request.

It works for me ... I have tested it with 


```
    @Test
    void testStopGradient() {

        try (NDManager manager = NDManager.newBaseManager()) {

            NDArray x = manager.create(new float[] {1.0f}, new Shape(1));
            x.attachGradient();
            try (GradientCollector gc = Engine.getInstance().newGradientCollector()) {
                NDArray y = x.mul(x);
                gc.backward(y);
                NDArray grad = x.getGradient();
                System.out.println("grad: " + grad);
                assertEquals(2f, grad.getFloat(0));
            }

            x = manager.create(new float[] {1.0f}, new Shape(1));
            x.attachGradient();
            try (GradientCollector gc = Engine.getInstance().newGradientCollector()) {
                NDArray z = x.mul(x.stopGradient());
                gc.backward(z);
                NDArray grad = x.getGradient();
                System.out.println("grad: " + grad);
                assertEquals(1f, grad.getFloat(0));
            }

        }
    }
```

