### PR TITLE
Minor fix in SageMaker SDK

### DIFF
--- a/extensions/aws-ai/src/main/java/ai/djl/aws/sagemaker/SageMaker.java
+++ b/extensions/aws-ai/src/main/java/ai/djl/aws/sagemaker/SageMaker.java
@@ -105,7 +105,11 @@ public final class SageMaker {
         s3 = builder.s3;
         iam = builder.iam;
         model = builder.model;
-        modelName = model.getName();
+        if (builder.modelName != null) {
+            modelName = builder.modelName;
+        } else {
+            modelName = model.getName();
+        }
         bucketName = builder.bucketName;
         bucketPath = builder.bucketPath;
         executionRole = builder.executionRole;
@@ -455,6 +459,7 @@ public final class SageMaker {
         String containerImage;
         String endpointConfigName;
         String endpointName;
+        String modelName;
         String instanceType = "ml.m4.xlarge";
         int instanceCount = 1;
         SageMakerClient sageMaker;
@@ -552,6 +557,19 @@ public final class SageMaker {
          */
         public Builder optEndpointName(String endpointName) {
             this.endpointName = endpointName;
+            return this;
+        }
+
+        /**
+         * Sets the optional model name to create.
+         *
+         * <p>If {@code modelName} is not set, model name will be used as model name.
+         *
+         * @param modelName the model name to create
+         * @return the builder
+         */
+        public Builder optModelName(String modelName) {
+            this.modelName = modelName;
             return this;
         }
 
@@ -658,10 +676,10 @@ public final class SageMaker {
                 bucketPath = bucketPath.substring(1);
             }
             if (endpointConfigName == null) {
-                endpointConfigName = model.getName();
+                endpointConfigName = modelName == null ? model.getName() : modelName;
             }
             if (endpointName == null) {
-                endpointName = model.getName();
+                endpointName = modelName == null ? model.getName() : modelName;
             }
 
             return new SageMaker(this);

--- a/extensions/aws-ai/src/test/java/ai/djl/aws/sagemaker/SageMakerTest.java
+++ b/extensions/aws-ai/src/test/java/ai/djl/aws/sagemaker/SageMakerTest.java
@@ -54,6 +54,7 @@ public class SageMakerTest {
                     SageMaker.builder()
                             .setModel(model)
                             .optBucketName("djl-sm-test")
+                            .optModelName("resnet")
                             .optContainerImage("125045733377.dkr.ecr.us-east-1.amazonaws.com/djl")
                             .optExecutionRole(
                                     "arn:aws:iam::125045733377:role/service-role/DJLSageMaker-ExecutionRole-20210213T1027050")


### PR DESCRIPTION
## Description ##

We want to re-use model name in case if user doesn't specify the endpoint and endpointconfig name. 

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
