### PR TITLE
Remove erroneous random forest application

### DIFF
--- a/api/src/main/java/ai/djl/Application.java
+++ b/api/src/main/java/ai/djl/Application.java
@@ -268,15 +268,6 @@ public class Application {
          * @see <a href="https://d2l.djl.ai/chapter_linear-networks/softmax-regression.html">The D2L
          *     chapter introducing this application</a>
          */
-        Application SOFTMAX_REGRESSION = new Application("tabular/linear_regression");
-
-        /**
-         * This is erroneous because random forest is a technique (not deep learning), not an
-         * application.
-         *
-         * <p>The actual application is likely to be in {@link Tabular}, especially {@link
-         * #SOFTMAX_REGRESSION}.
-         */
-        Application RANDOM_FOREST = new Application("tabular/random_forest");
+        Application SOFTMAX_REGRESSION = new Application("tabular/softmax_regression");
     }
 }

--- a/jupyter/onnxruntime/machine_learning_with_ONNXRuntime.ipynb
+++ b/jupyter/onnxruntime/machine_learning_with_ONNXRuntime.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "String modelUrl = \"https://mlrepo.djl.ai/model/tabular/random_forest/ai/djl/onnxruntime/iris_flowers/0.0.1/iris_flowers.zip\";\n",
+    "String modelUrl = \"https://mlrepo.djl.ai/model/tabular/softmax_regression/ai/djl/onnxruntime/iris_flowers/0.0.1/iris_flowers.zip\";\n",
     "Criteria<IrisFlower, Classifications> criteria = Criteria.builder()\n",
     "        .setTypes(IrisFlower.class, Classifications.class)\n",
     "        .optModelUrls(modelUrl)\n",

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/OrtModelZoo.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/OrtModelZoo.java
@@ -13,7 +13,7 @@
 package ai.djl.onnxruntime.zoo;
 
 import ai.djl.onnxruntime.engine.OrtEngine;
-import ai.djl.onnxruntime.zoo.tabular.randomforest.IrisClassificationModelLoader;
+import ai.djl.onnxruntime.zoo.tabular.softmax_regression.IrisClassificationModelLoader;
 import ai.djl.repository.Repository;
 import ai.djl.repository.zoo.ModelZoo;
 import java.util.Collections;

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/tabular/softmax_regression/IrisClassificationModelLoader.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/tabular/softmax_regression/IrisClassificationModelLoader.java
@@ -10,9 +10,10 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package ai.djl.onnxruntime.zoo.tabular.randomforest;
+package ai.djl.onnxruntime.zoo.tabular.softmax_regression;
 
 import ai.djl.Application;
+import ai.djl.Application.Tabular;
 import ai.djl.MalformedModelException;
 import ai.djl.Model;
 import ai.djl.modality.Classifications;
@@ -39,7 +40,7 @@ import java.util.Map;
 /** Model loader for onnx iris_flowers models. */
 public class IrisClassificationModelLoader extends BaseModelLoader {
 
-    private static final Application APPLICATION = Application.Tabular.RANDOM_FOREST;
+    private static final Application APPLICATION = Tabular.SOFTMAX_REGRESSION;
     private static final String GROUP_ID = OrtModelZoo.GROUP_ID;
     private static final String ARTIFACT_ID = "iris_flowers";
     private static final String VERSION = "0.0.1";

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/tabular/softmax_regression/IrisFlower.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/tabular/softmax_regression/IrisFlower.java
@@ -10,7 +10,7 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package ai.djl.onnxruntime.zoo.tabular.randomforest;
+package ai.djl.onnxruntime.zoo.tabular.softmax_regression;
 
 /** A class holds the iris flower features. */
 public class IrisFlower {

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/tabular/softmax_regression/package-info.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/zoo/tabular/softmax_regression/package-info.java
@@ -14,4 +14,4 @@
 /**
  * Contains classes for the classification models in the {@link ai.djl.onnxruntime.zoo.OrtModelZoo}.
  */
-package ai.djl.onnxruntime.zoo.tabular.randomforest;
+package ai.djl.onnxruntime.zoo.tabular.softmax_regression;

--- a/onnxruntime/onnxruntime-engine/src/test/java/ai/djl/onnxruntime/engine/OrtTest.java
+++ b/onnxruntime/onnxruntime-engine/src/test/java/ai/djl/onnxruntime/engine/OrtTest.java
@@ -20,7 +20,7 @@ import ai.djl.modality.Classifications;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.types.Shape;
-import ai.djl.onnxruntime.zoo.tabular.randomforest.IrisFlower;
+import ai.djl.onnxruntime.zoo.tabular.softmax_regression.IrisFlower;
 import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ModelNotFoundException;
 import ai.djl.repository.zoo.ModelZoo;

--- a/onnxruntime/onnxruntime-engine/src/test/resources/mlrepo/model/tabular/softmax_regression/ai/djl/onnxruntime/iris_flowers/metadata.json
+++ b/onnxruntime/onnxruntime-engine/src/test/resources/mlrepo/model/tabular/softmax_regression/ai/djl/onnxruntime/iris_flowers/metadata.json
@@ -1,7 +1,7 @@
 {
   "metadataVersion": "0.2",
   "resourceType": "model",
-  "application": "tabular/random_forest",
+  "application": "tabular/softmax_regression",
   "groupId": "ai.djl.onnxruntime",
   "artifactId": "iris_flowers",
   "name": "iris_flowers",


### PR DESCRIPTION
The application in the only place used was changed to the more accurate softmax_regression (matching
the terminology from the D2L book).