### PR TITLE
Fix one array case for concat

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArrays.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrays.java
@@ -13,6 +13,7 @@
 package ai.djl.ndarray;
 
 import ai.djl.ndarray.types.Shape;
+import ai.djl.util.Preconditions;
 import java.util.Arrays;
 
 /** This class contains various methods for manipulating NDArrays. */
@@ -1818,6 +1819,7 @@ public final class NDArrays {
      *     the the {@link NDArray}
      */
     public static NDArray stack(NDList arrays, int axis) {
+        Preconditions.checkArgument(arrays.size() > 0, "need at least one array to stack");
         NDArray array = arrays.head();
         return array.getNDArrayInternal().stack(arrays.subNDList(1), axis);
     }
@@ -1871,6 +1873,10 @@ public final class NDArrays {
      * @return the concatenated {@link NDArray}
      */
     public static NDArray concat(NDList arrays, int axis) {
+        Preconditions.checkArgument(arrays.size() > 0, "need at least one array to concatenate");
+        if (arrays.size() == 1) {
+            return arrays.singletonOrThrow().duplicate();
+        }
         NDArray array = arrays.head();
         return array.getNDArrayInternal().concat(arrays.subNDList(1), axis);
     }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayShapesManipulationOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayShapesManipulationOpTest.java
@@ -217,6 +217,11 @@ public class NDArrayShapesManipulationOpTest {
             expected = manager.create(new Shape(0, 0, 2));
             Assert.assertEquals(array1.stack(array1, 2), expected);
             Assert.assertEquals(NDArrays.stack(new NDList(array1, array1), 2), expected);
+
+            // one array
+            array1 = manager.ones(new Shape(2, 2));
+            expected = manager.ones(new Shape(1, 2, 2));
+            Assert.assertEquals(NDArrays.stack(new NDList(array1)), expected);
         }
     }
 
@@ -254,6 +259,11 @@ public class NDArrayShapesManipulationOpTest {
             array1 = manager.create(1f);
             array2 = manager.create(2f);
             array1.concat(array2);
+
+            // one array
+            array1 = manager.ones(new Shape(2, 2));
+            expected = manager.ones(new Shape(2, 2));
+            Assert.assertEquals(NDArrays.concat(new NDList(array1)), expected);
         }
     }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
