### PR TITLE
remove exclusion for pytorch and tf from jacoco

### DIFF
--- a/tensorflow/tensorflow-engine/build.gradle
+++ b/tensorflow/tensorflow-engine/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     api project(":api")
     api project(":tensorflow:tensorflow-api")
 
+    testImplementation(project(":testing"))
     testImplementation("org.testng:testng:${testng_version}") {
         exclude group: "junit", module: "junit"
     }

--- a/tensorflow/tensorflow-engine/src/test/java/ai/djl/tensorflow/integration/TfCoverageTest.java
+++ b/tensorflow/tensorflow-engine/src/test/java/ai/djl/tensorflow/integration/TfCoverageTest.java
@@ -14,10 +14,9 @@ package ai.djl.tensorflow.integration;
 
 import ai.djl.tensorflow.engine.TfEngine;
 import ai.djl.testing.CoverageUtils;
-import org.testng.annotations.Test;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
+import org.testng.annotations.Test;
 
 public class TfCoverageTest {
 

--- a/tensorflow/tensorflow-engine/src/test/java/ai/djl/tensorflow/integration/TfCoverageTest.java
+++ b/tensorflow/tensorflow-engine/src/test/java/ai/djl/tensorflow/integration/TfCoverageTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.tensorflow.integration;
+
+import ai.djl.tensorflow.engine.TfEngine;
+import ai.djl.testing.CoverageUtils;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+public class TfCoverageTest {
+
+    @Test
+    public void test() throws IOException, ReflectiveOperationException, URISyntaxException {
+        // tensorflow-engine
+        CoverageUtils.testGetterSetters(TfEngine.class);
+    }
+}

--- a/tensorflow/tensorflow-engine/src/test/java/ai/djl/tensorflow/integration/package-info.java
+++ b/tensorflow/tensorflow-engine/src/test/java/ai/djl/tensorflow/integration/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+/** The integration test for testing TensorFlow specific features. */
+package ai.djl.tensorflow.integration;

--- a/tools/gradle/jacoco.gradle
+++ b/tools/gradle/jacoco.gradle
@@ -14,7 +14,7 @@ task jacocoMergeTestData(type: JacocoMerge) {
     }
 }
 
-def exclusions = [":examples", ":integration", ":pytorch:pytorch-engine", ":tensorflow:tensorflow-engine"]
+def exclusions = [":examples", ":integration"]
 
 task jacocoRootReport(type: JacocoReport) {
     dependsOn jacocoMergeTestData


### PR DESCRIPTION
## Description ##

Add PyTorch and TensorFlow back to Jacoco report