### PR TITLE
Fix LSTM nightly build failure

### DIFF
--- a/examples/src/main/java/ai/djl/examples/training/TrainSentimentAnalysis.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainSentimentAnalysis.java
@@ -234,7 +234,7 @@ public final class TrainSentimentAnalysis {
             for (TextProcessor processor : TEXT_PROCESSORS) {
                 tokens = processor.preprocess(tokens);
             }
-            NDArray array = textEmbedding.embedText(manager, tokens);
+            NDArray array = manager.create(textEmbedding.preprocessTextToEmbed(tokens));
             return new NDList(array);
         }
 
@@ -243,7 +243,7 @@ public final class TrainSentimentAnalysis {
         public Batchifier getBatchifier() {
             return PaddingStackBatchifier.builder()
                     .optIncludeValidLengths(false)
-                    .addPad(0, 0, m -> m.ones(new Shape(1, 50)).mul(paddingTokenValue))
+                    .addPad(0, 0, m -> m.ones(new Shape(1)).mul(paddingTokenValue))
                     .build();
         }
     }


### PR DESCRIPTION
We do the double embedding (one in the model for training, the other in the Translator for prediction).
The PR removes the embedding part in Translator and just convert the token to indices without duplicate embedding