### PR TITLE
Remove Github Actions jobs that require tokens for forks

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'awslabs/djl'
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
@@ -137,6 +138,7 @@ jobs:
 
   # Windows platform for testing hybrid engines
   build-windows:
+    if: github.repository == 'awslabs/djl'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   documentation:
+    if: github.repository == 'awslabs/djl'
     runs-on: ubuntu-18.04
     steps:
       - name: Set up JDK 11


### PR DESCRIPTION
## Description ##

Remove Github Actions jobs that require tokens for forked repositories. Currently forked repositories run Github Actions but always fail. In addition, docs is ran on a cron job so every week the forked repositories receive an failure build.