### PR TITLE
add boolean set method to DJL

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -470,6 +470,16 @@ public interface NDArray extends NDResource {
     }
 
     /**
+     * Sets the {@code NDArray} by boolean mask.
+     *
+     * @param index the boolean {@code NDArray} that indicates what to get
+     * @param value the value to replace with
+     */
+    default void set(NDArray index, Number value) {
+        set(new NDIndex().addBooleanIndex(index), value);
+    }
+
+    /**
      * Sets the specified scalar in this {@code NDArray} with the given value.
      *
      * @param index the single index to update
@@ -3545,6 +3555,16 @@ public interface NDArray extends NDResource {
      * @return the cumulative sum along the specified axis
      */
     NDArray cumSum(int axis);
+
+    /**
+     * Replace the handle of the NDArray with the other. The NDArray used for replacement will be
+     * killed.
+     *
+     * <p>Please use with caution, this method will make the input argument unusable.
+     *
+     * @param replaced the handle provider that will be killed
+     */
+    void intern(NDArray replaced);
 
     /**
      * Returns the boolean {@code NDArray} with value {@code true} where this {@code NDArray}'s

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -785,6 +785,12 @@ public interface NDArrayAdapter extends NDArray {
 
     /** {@inheritDoc} */
     @Override
+    default void intern(NDArray replaced) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     default NDArray isInfinite() {
         throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
@@ -218,6 +218,17 @@ public class NDArrayOtherOpTest {
         }
     }
 
+    @Test
+    public void testIntern() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray original = manager.ones(new Shape(3, 2));
+            NDArray replaced = manager.zeros(new Shape(5, 5));
+            original.intern(replaced);
+            Assert.assertEquals(original, manager.zeros(new Shape(5, 5)));
+            Assert.assertThrows(IllegalStateException.class, replaced::toFloatArray);
+        }
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBooleanMask() {
         try (NDManager manager = NDManager.newBaseManager()) {
@@ -274,6 +285,18 @@ public class NDArrayOtherOpTest {
                         NDArray ndArray = manager.create(1f);
                         ndArray.set(FloatBuffer.wrap(new float[] {-1, 1}));
                     });
+        }
+    }
+
+    @Test
+    public void testSetBoolean() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray array = manager.arange(0f, 6f).reshape(2, 3);
+            array.set(array.gte(2), 10f);
+            NDArray expected = manager.create(new float[] {0, 1, 10, 10, 10, 10}, new Shape(2, 3));
+            Assert.assertEquals(array, expected);
+            array.set(array.lt(-1), -1f);
+            Assert.assertEquals(array, expected);
         }
     }
 

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -1232,6 +1232,17 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
+    public void intern(NDArray replaced) {
+        MxNDArray arr = (MxNDArray) replaced;
+        Pointer oldHandle = handle.getAndSet(arr.handle.getAndSet(null));
+        JnaUtils.waitToRead(oldHandle);
+        JnaUtils.freeNdArray(oldHandle);
+        // dereference old ndarray
+        arr.close();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDArray isInfinite() {
         throw new UnsupportedOperationException("Not implemented yet.");
     }
@@ -1613,8 +1624,7 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
         if (pointer != null) {
             JnaUtils.waitToRead(pointer);
             JnaUtils.freeNdArray(pointer);
-            manager.detachInternal(getUid());
-            manager = null;
         }
+        manager.detachInternal(getUid());
     }
 }

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -971,6 +971,13 @@ class MxNDArrayEx implements NDArrayEx {
                 (condition.getDataType() == DataType.BOOLEAN)
                         ? condition.toType(DataType.INT32, false)
                         : condition;
+        if (array.getDataType() != other.getDataType()) {
+            throw new IllegalArgumentException(
+                    "DataType mismatch, required "
+                            + array.getDataType()
+                            + " actual "
+                            + other.getDataType());
+        }
         if (!array.shapeEquals(other)) {
             Shape res = deriveBroadcastedShape(array.getShape(), other.getShape());
             array1 = (!res.equals(array.getShape())) ? array.broadcast(res) : array;

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
@@ -15,7 +15,6 @@ package ai.djl.mxnet.engine;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.index.NDArrayIndexer;
-import ai.djl.ndarray.index.dim.NDIndexBooleans;
 import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
 import ai.djl.ndarray.types.Shape;
@@ -86,12 +85,6 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
                 toClean.close();
             }
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void set(NDArray array, NDIndexBooleans indices, NDArray value) {
-        throw new UnsupportedOperationException("Setting with a boolean mask is not yet supported");
     }
 
     /** {@inheritDoc} */

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -1110,6 +1110,16 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public void intern(NDArray replaced) {
+        PtNDArray arr = (PtNDArray) replaced;
+        Long oldHandle = handle.getAndSet(arr.handle.getAndSet(null));
+        JniUtils.deleteNDArray(oldHandle);
+        // dereference old ndarray
+        arr.close();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public PtNDArray isInfinite() {
         return JniUtils.isInf(this);
     }
@@ -1439,9 +1449,8 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         Long pointer = handle.getAndSet(null);
         if (pointer != null) {
             JniUtils.deleteNDArray(pointer);
-            manager.detachInternal(getUid());
-            manager = null;
-            dataRef = null;
         }
+        manager.detachInternal(getUid());
+        dataRef = null;
     }
 }

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -1532,6 +1532,12 @@ public class TfNDArray implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public void intern(NDArray replaced) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDArray cumSum() {
         return cumSum(0);
     }

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -1532,14 +1532,14 @@ public class TfNDArray implements NDArray {
 
     /** {@inheritDoc} */
     @Override
-    public void intern(NDArray replaced) {
-        throw new UnsupportedOperationException("Not implemented");
+    public NDArray cumSum() {
+        return cumSum(0);
     }
 
     /** {@inheritDoc} */
     @Override
-    public NDArray cumSum() {
-        return cumSum(0);
+    public void intern(NDArray replaced) {
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     /** {@inheritDoc} */

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayIndexer.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayIndexer.java
@@ -14,7 +14,6 @@ package ai.djl.tensorflow.engine;
 
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.index.NDArrayIndexer;
-import ai.djl.ndarray.index.dim.NDIndexBooleans;
 import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
 import java.util.Arrays;
@@ -59,12 +58,6 @@ public class TfNDArrayIndexer extends NDArrayIndexer {
     /** {@inheritDoc} */
     @Override
     public void set(NDArray array, NDIndexFullSlice fullSlice, NDArray value) {
-        throw new UnsupportedOperationException("Tensor cannot be modified after creation");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void set(NDArray array, NDIndexBooleans indices, NDArray value) {
         throw new UnsupportedOperationException("Tensor cannot be modified after creation");
     }
 


### PR DESCRIPTION
## Description ##

Boolean set method for DJL use cases. Also added TF where method.

This PR also introduced the NDArray.intern(): This method aimed to inplace change the reference of NDArray and kill the old reference owner. Typically useful if user would like to reduce object creation in Java.