### PR TITLE
Fixes TrainBertOnCode and temp attach chains

### DIFF
--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -20,6 +20,7 @@ import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.ndarray.types.SparseFormat;
@@ -386,6 +387,11 @@ public class MxNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void attachInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override


### PR DESCRIPTION
fixes #763

This first fixes the PointwiseFeedForwardBlock and simplifies it by having it
extend the SequentialBlock.

Then, it fixes an issue with the NDManager when a resource that was tempAttached
is then tempAttached again. So, the resource moves from managers A -> B -> C. It
was attached in A, got tempAttached to B, then tempAttached to C. When C was
closed, the resource was normal attached in B so it was closed too early. This
PR makes B remember detached temp resources, so even when it is returned from C
to B, B still knows that it should be tempAttached to return to A.