### PR TITLE
Improve TensorFlow new architecture refactoring

### DIFF
--- a/api/src/main/java/ai/djl/engine/Engine.java
+++ b/api/src/main/java/ai/djl/engine/Engine.java
@@ -57,6 +57,9 @@ public abstract class Engine {
 
     private Device defaultDevice;
 
+    // use object to check if it's set
+    private Integer seed;
+
     private static synchronized String initEngine() {
         ServiceLoader<EngineProvider> loaders = ServiceLoader.load(EngineProvider.class);
         for (EngineProvider provider : loaders) {
@@ -251,7 +254,18 @@ public abstract class Engine {
      *
      * @param seed the seed to be fixed in Engine
      */
-    public abstract void setRandomSeed(int seed);
+    public void setRandomSeed(int seed) {
+        this.seed = seed;
+    }
+
+    /**
+     * Returns the random seed in DJL Engine.
+     *
+     * @return seed the seed to be fixed in Engine
+     */
+    public Integer getSeed() {
+        return seed;
+    }
 
     /** Prints debug information about the environment for debugging environment issues. */
     @SuppressWarnings("PMD.SystemPrintln")

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayElementArithmeticOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayElementArithmeticOpTest.java
@@ -629,7 +629,7 @@ public class NDArrayElementArithmeticOpTest {
             NDArray inPlaceResult = array.powi(2);
             NDArray expected = manager.create(new float[] {36, 0, 1, 25, 4}, new Shape(1, 5));
             Assertions.assertAlmostEquals(result, expected);
-            Assertions.assertInPlaceAlmostEquals(inPlaceResult, expected, array);
+            Assertions.assertInPlaceAlmostEquals(inPlaceResult, expected, array, 1e-5, 2e-3);
 
             testScalarCornerCase(manager, NDArray::pow, (x, y) -> (float) Math.pow(x, y), false);
             testScalarCornerCase(manager, NDArray::powi, (x, y) -> (float) Math.pow(x, y), true);

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
@@ -148,6 +148,7 @@ public final class MxEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public void setRandomSeed(int seed) {
+        super.setRandomSeed(seed);
         JnaUtils.randomSeed(seed);
         RandomUtils.RANDOM.setSeed(seed);
     }

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
@@ -115,6 +115,7 @@ public final class PtEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public void setRandomSeed(int seed) {
+        super.setRandomSeed(seed);
         JniUtils.setSeed(seed);
         RandomUtils.RANDOM.setSeed(seed);
     }

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/SavedModelBundle.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/SavedModelBundle.java
@@ -1,14 +1,27 @@
-package ai.djl.tensorflow.engine;
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 
-import static org.tensorflow.internal.c_api.global.tensorflow.*;
+package ai.djl.tensorflow.engine;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.bytedeco.javacpp.PointerScope;
 import org.tensorflow.internal.c_api.TF_Graph;
 import org.tensorflow.internal.c_api.TF_Session;
 import org.tensorflow.internal.c_api.TF_Status;
+import org.tensorflow.internal.c_api.global.tensorflow;
 import org.tensorflow.proto.framework.MetaGraphDef;
 
+/** The wrapper class for native resources required for SavedModelBundle. */
 public class SavedModelBundle implements AutoCloseable {
 
     private TF_Graph graphHandle;
@@ -24,18 +37,34 @@ public class SavedModelBundle implements AutoCloseable {
         closed = new AtomicBoolean(false);
     }
 
+    /**
+     * Returns the graph handle.
+     *
+     * @return the graph handle
+     */
     public TF_Graph getGraph() {
         return graphHandle;
     }
 
+    /**
+     * Returns the session handle.
+     *
+     * @return the session handle
+     */
     public TF_Session getSession() {
         return sessionHandle;
     }
 
+    /**
+     * Returns the MetaGraphDef protol buf.
+     *
+     * @return the MetaGraphDef protol buf
+     */
     public MetaGraphDef getMetaGraphDef() {
         return metaGraphDef;
     }
 
+    /** {@inheritDoc} */
     @SuppressWarnings({"unchecked", "try"})
     @Override
     public void close() {
@@ -50,11 +79,13 @@ public class SavedModelBundle implements AutoCloseable {
         // as the default session's deallocator in org/tensorflow/c_api/internal/TF_Session.java
         // have not released status and called throwExceptionIfNotOK
         // usually we should prefer to use default deallocator as much as possible
+        // the code is fixed in upstream tensorflow java, we can refactor with their next releaase
+        // https://github.com/tensorflow/java/pull/253/files
         try (PointerScope scope = new PointerScope()) {
             TF_Status status = TF_Status.newStatus();
-            TF_CloseSession(sessionHandle, status);
+            tensorflow.TF_CloseSession(sessionHandle, status);
             // Result of close is ignored, delete anyway.
-            TF_DeleteSession(sessionHandle, status);
+            tensorflow.TF_DeleteSession(sessionHandle, status);
             status.throwExceptionIfNotOK();
         }
         metaGraphDef = null;

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfOpExecutor.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfOpExecutor.java
@@ -13,8 +13,6 @@
 
 package ai.djl.tensorflow.engine;
 
-import static org.tensorflow.internal.c_api.global.tensorflow.*;
-
 import ai.djl.Device;
 import ai.djl.engine.EngineException;
 import ai.djl.ndarray.NDArray;
@@ -31,13 +29,10 @@ import org.tensorflow.internal.c_api.TFE_Context;
 import org.tensorflow.internal.c_api.TFE_Op;
 import org.tensorflow.internal.c_api.TFE_TensorHandle;
 import org.tensorflow.internal.c_api.TF_Status;
+import org.tensorflow.internal.c_api.global.tensorflow;
 
 /** An {@code TfOpExecutor} for executing TensorFlow operation eagerly. */
 final class TfOpExecutor implements AutoCloseable {
-
-    /** This value should be >= to the maximum number of outputs in any op */
-    public static final int MAX_OUTPUTS_PER_OP =
-            Integer.parseInt(System.getProperty("ai.djl.tensorflow.max_outputs_per_op", "1000"));
 
     private TfNDManager manager;
     private TFE_Op opHandle;
@@ -58,16 +53,15 @@ final class TfOpExecutor implements AutoCloseable {
 
     // please make sure you close the output manually or attach to NDManager
     @SuppressWarnings({"unchecked", "try"})
-    private TFE_TensorHandle[] execute(TFE_Op opHandle) {
+    private TFE_TensorHandle[] execute(TFE_Op opHandle, int numOutputs) {
         try (PointerScope scope = new PointerScope()) {
-            IntPointer numReturnValues = new IntPointer(1).put(MAX_OUTPUTS_PER_OP);
-            PointerPointer<TFE_TensorHandle> returnValues =
-                    new PointerPointer<>(MAX_OUTPUTS_PER_OP);
+            IntPointer numReturnValues = new IntPointer(1).put(numOutputs);
+            PointerPointer<TFE_TensorHandle> returnValues = new PointerPointer<>(numOutputs);
             TF_Status status = TF_Status.newStatus();
             // TODO(improvement): check if TFE_Execute is able to be called twice
             // and evaluate if it worth calling the TFE_Execute twice to get the # of outputs
             // in sacrifice of performance
-            TFE_Execute(opHandle, returnValues, numReturnValues, status);
+            tensorflow.TFE_Execute(opHandle, returnValues, numReturnValues, status);
             status.throwExceptionIfNotOK();
 
             TFE_TensorHandle[] results = new TFE_TensorHandle[numReturnValues.get()];
@@ -82,21 +76,23 @@ final class TfOpExecutor implements AutoCloseable {
         }
     }
 
-    public NDArray[] build() {
-        TFE_TensorHandle[] handles = execute(opHandle);
-        NDArray[] outputs = new NDArray[handles.length];
-        for (int i = 0; i < handles.length; ++i) {
-            // attach the TfNDArray along with pointer to manager
-            outputs[i] = new TfNDArray(manager, handles[i]);
+    public NDArray[] build(int numOutputs) {
+        try {
+            TFE_TensorHandle[] handles = execute(opHandle, numOutputs);
+            NDArray[] outputs = new NDArray[handles.length];
+            for (int i = 0; i < handles.length; ++i) {
+                // attach the TfNDArray along with pointer to manager
+                outputs[i] = new TfNDArray(manager, handles[i]);
+            }
+            return outputs;
+        } finally {
+            close();
         }
-        // close the opHandle
-        opHandle.close();
-        return outputs;
     }
 
     public NDArray buildSingletonOrThrow() {
         try {
-            TFE_TensorHandle[] handles = execute(opHandle);
+            TFE_TensorHandle[] handles = execute(opHandle, 1);
             Preconditions.checkArgument(
                     handles.length == 1,
                     "The expected size of outputs is 1 but got " + handles.length);
@@ -110,7 +106,7 @@ final class TfOpExecutor implements AutoCloseable {
     public TfOpExecutor addInput(NDArray input) {
         try (PointerScope scope = new PointerScope()) {
             TF_Status status = TF_Status.newStatus();
-            TFE_OpAddInput(opHandle, ((TfNDArray) input).getHandle(), status);
+            tensorflow.TFE_OpAddInput(opHandle, ((TfNDArray) input).getHandle(), status);
             status.throwExceptionIfNotOK();
         }
         return this;
@@ -129,7 +125,7 @@ final class TfOpExecutor implements AutoCloseable {
                 tensorPointers.put(i, inputHandles[i]);
             }
             TF_Status status = TF_Status.newStatus();
-            TFE_OpAddInputList(opHandle, tensorPointers, inputHandles.length, status);
+            tensorflow.TFE_OpAddInputList(opHandle, tensorPointers, inputHandles.length, status);
             status.throwExceptionIfNotOK();
         }
         return this;
@@ -148,7 +144,7 @@ final class TfOpExecutor implements AutoCloseable {
                         "Unknown device type to TensorFlow Engine: " + device.toString());
             }
             TF_Status status = TF_Status.newStatus();
-            TFE_OpSetDevice(opHandle, deviceStr, status);
+            tensorflow.TFE_OpSetDevice(opHandle, deviceStr, status);
             status.throwExceptionIfNotOK();
             return this;
         } finally {
@@ -160,33 +156,33 @@ final class TfOpExecutor implements AutoCloseable {
     public TfOpExecutor addParam(String name, String value) {
         byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
         try (PointerScope scope = new PointerScope()) {
-            TFE_OpSetAttrString(opHandle, name, new BytePointer(bytes), bytes.length);
+            tensorflow.TFE_OpSetAttrString(opHandle, name, new BytePointer(bytes), bytes.length);
         }
         return this;
     }
 
     public TfOpExecutor addParam(String name, long value) {
-        TFE_OpSetAttrInt(opHandle, name, value);
+        tensorflow.TFE_OpSetAttrInt(opHandle, name, value);
         return this;
     }
 
     public TfOpExecutor addParam(String name, float value) {
-        TFE_OpSetAttrFloat(opHandle, name, value);
+        tensorflow.TFE_OpSetAttrFloat(opHandle, name, value);
         return this;
     }
 
     public TfOpExecutor addParam(String name, boolean value) {
-        TFE_OpSetAttrBool(opHandle, name, (byte) (value ? 1 : 0));
+        tensorflow.TFE_OpSetAttrBool(opHandle, name, (byte) (value ? 1 : 0));
         return this;
     }
 
     public TfOpExecutor addParam(String name, DataType dataType) {
-        TFE_OpSetAttrType(opHandle, name, TfDataType.toTf(dataType));
+        tensorflow.TFE_OpSetAttrType(opHandle, name, TfDataType.toTf(dataType));
         return this;
     }
 
     public TfOpExecutor addParam(String name, long[] values) {
-        TFE_OpSetAttrIntList(opHandle, name, values, values.length);
+        tensorflow.TFE_OpSetAttrIntList(opHandle, name, values, values.length);
         return this;
     }
 

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/javacpp/LibUtils.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/javacpp/LibUtils.java
@@ -48,6 +48,7 @@ public final class LibUtils {
             String path = new File(libName).getParentFile().toString();
             System.setProperty("org.bytedeco.javacpp.platform.preloadpath", path);
             // workaround javacpp physical memory check bug
+            System.setProperty("org.bytedeco.javacpp.maxBytes", "0");
             System.setProperty("org.bytedeco.javacpp.maxPhysicalBytes", "0");
         }
         // defer to tensorflow-core-api to handle loading native library.

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/javacpp/package-info.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/javacpp/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * Contains implementations of interfaces within the DJL API for the Tensorflow Engine.
+ *
+ * @see ai.djl.tensorflow.engine.TfEngine
+ */
+package ai.djl.tensorflow.engine.javacpp;

--- a/testing/src/main/java/ai/djl/testing/Assertions.java
+++ b/testing/src/main/java/ai/djl/testing/Assertions.java
@@ -87,7 +87,7 @@ public final class Assertions {
             double a = actualDoubleArray[i].doubleValue();
             double b = expectedDoubleArray[i].doubleValue();
             if (Math.abs(a - b) > (atol + rtol * Math.abs(b))) {
-                throw new AssertionError(getDefaultErrorMessage(actual, expected));
+                throw new AssertionError("Expected:" + b + "but got " + a);
             }
         }
     }


### PR DESCRIPTION
1. move the EagerSession to engine level
2. add operators back
3. use cached input metatdata so we don't do session feed and fetch on every inference but only on the first one
4. TfOpExecutor requires users to specify the # of outputs (99% op have only 1 ouput and the rest should be easy to infer the # output from the operator & parameters itself) for better memory usage & potential performance gain