### PR TITLE
Reduce the Conv testing during normal run

### DIFF
--- a/api/src/test/java/ai/djl/nn/convolutional/Conv1dTest.java
+++ b/api/src/test/java/ai/djl/nn/convolutional/Conv1dTest.java
@@ -40,7 +40,16 @@ public class Conv1dTest extends OutputShapeTest {
                         * strideWidthRange.size()
                         * dilationWidthRange.size();
 
-        IntStream.range(0, (int) rows)
+        IntStream streamToTest;
+        if (Boolean.getBoolean("nightly")) {
+            // During nightly testing, test all rows
+            streamToTest = IntStream.range(0, (int) rows);
+        } else {
+            // During unit testing, only test the first and last
+            streamToTest = IntStream.of(0, (int) rows - 1);
+        }
+
+        streamToTest
                 .mapToObj(TestData::new)
                 .peek(
                         td -> {

--- a/api/src/test/java/ai/djl/nn/convolutional/Conv1dTransposeTest.java
+++ b/api/src/test/java/ai/djl/nn/convolutional/Conv1dTransposeTest.java
@@ -42,7 +42,16 @@ public class Conv1dTransposeTest extends OutputShapeTest {
                         * strideWidthRange.size()
                         * dilationWidthRange.size();
 
-        IntStream.range(0, (int) rows)
+        IntStream streamToTest;
+        if (Boolean.getBoolean("nightly")) {
+            // During nightly testing, test all rows
+            streamToTest = IntStream.range(0, (int) rows);
+        } else {
+            // During unit testing, only test the first and last
+            streamToTest = IntStream.of(0, (int) rows - 1);
+        }
+
+        streamToTest
                 .mapToObj(TestData::new)
                 .peek(
                         td -> {

--- a/api/src/test/java/ai/djl/nn/convolutional/Conv2dTest.java
+++ b/api/src/test/java/ai/djl/nn/convolutional/Conv2dTest.java
@@ -53,7 +53,16 @@ public class Conv2dTest extends OutputShapeTest {
                         * dilationHeightRange.size()
                         * dilationWidthRange.size();
 
-        IntStream.range(0, (int) rows)
+        IntStream streamToTest;
+        if (Boolean.getBoolean("nightly")) {
+            // During nightly testing, test all rows
+            streamToTest = IntStream.range(0, (int) rows);
+        } else {
+            // During unit testing, only test the first and last
+            streamToTest = IntStream.of(0, (int) rows - 1);
+        }
+
+        streamToTest
                 .mapToObj(TestData::new)
                 .peek(
                         td -> {

--- a/api/src/test/java/ai/djl/nn/convolutional/Conv2dTransposeTest.java
+++ b/api/src/test/java/ai/djl/nn/convolutional/Conv2dTransposeTest.java
@@ -58,7 +58,16 @@ public class Conv2dTransposeTest extends OutputShapeTest {
                         * dilationHeightRange.size()
                         * dilationWidthRange.size();
 
-        IntStream.range(0, (int) rows)
+        IntStream streamToTest;
+        if (Boolean.getBoolean("nightly")) {
+            // During nightly testing, test all rows
+            streamToTest = IntStream.range(0, (int) rows);
+        } else {
+            // During unit testing, only test the first and last
+            streamToTest = IntStream.of(0, (int) rows - 1);
+        }
+
+        streamToTest
                 .mapToObj(TestData::new)
                 .peek(
                         td -> {

--- a/api/src/test/java/ai/djl/nn/convolutional/Conv3dTest.java
+++ b/api/src/test/java/ai/djl/nn/convolutional/Conv3dTest.java
@@ -63,7 +63,16 @@ public class Conv3dTest extends OutputShapeTest {
                         * dilationHeightRange.size()
                         * dilationWidthRange.size();
 
-        IntStream.range(0, (int) rows)
+        IntStream streamToTest;
+        if (Boolean.getBoolean("nightly")) {
+            // During nightly testing, test all rows
+            streamToTest = IntStream.range(0, (int) rows);
+        } else {
+            // During unit testing, only test the first and last
+            streamToTest = IntStream.of(0, (int) rows - 1);
+        }
+
+        streamToTest
                 .mapToObj(TestData::new)
                 .peek(
                         td -> {


### PR DESCRIPTION
Currently, the convolution testing tests with a range of inputs across a number
of variables. This increases the test duration a bit much for the standard unit
test suite.

Instead, I reduce down to only two tests for unit testing. During nightly, the
full combination of ranges will be used.