### PR TITLE
Fixing SequenceMask bug related to Issue #802

### DIFF
--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -386,9 +386,9 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
     /** {@inheritDoc} */
     @Override
     public NDArray sequenceMask(NDArray sequenceLength, float value) {
-        if (getShape().dimension() < 3 || getShape().isScalar() || getShape().hasZeroDimension()) {
+        if (getShape().dimension() < 2 || getShape().isScalar() || getShape().hasZeroDimension()) {
             throw new IllegalArgumentException(
-                    "sequenceMask is not supported for NDArray with less than 3 dimensions");
+                    "sequenceMask is not supported for NDArray with less than 2 dimensions");
         }
         Shape expectedSequenceLengthShape = new Shape(getShape().get(0));
         if (!sequenceLength.getShape().equals(expectedSequenceLengthShape)) {


### PR DESCRIPTION
## Description ##

Fixing #802 . I received response from MXNet team that indeed this was just a typo. We can see the check that throws error only if n=1 here https://github.com/apache/incubator-mxnet/blob/master/src/operator/sequence_reverse-inl.h#L235

