### PR TITLE
Defer engine initialization

### DIFF
--- a/api/src/main/java/ai/djl/engine/Engine.java
+++ b/api/src/main/java/ai/djl/engine/Engine.java
@@ -49,11 +49,9 @@ public abstract class Engine {
 
     private static final Logger logger = LoggerFactory.getLogger(Engine.class);
 
-    private static final Map<String, Engine> ALL_ENGINES = new ConcurrentHashMap<>();
+    private static final Map<String, EngineProvider> ALL_ENGINES = new ConcurrentHashMap<>();
 
     private static final String DEFAULT_ENGINE = initEngine();
-
-    private static EngineException exception;
 
     private Device defaultDevice;
 
@@ -63,14 +61,8 @@ public abstract class Engine {
     private static synchronized String initEngine() {
         ServiceLoader<EngineProvider> loaders = ServiceLoader.load(EngineProvider.class);
         for (EngineProvider provider : loaders) {
-            try {
-                Engine engine = provider.getEngine();
-                logger.debug("Engine loaded from provider: {}", engine.getEngineName());
-                ALL_ENGINES.put(engine.getEngineName(), engine);
-            } catch (EngineException e) {
-                exception = e;
-                logger.warn("Failed to load engine from: " + provider.getClass().getName(), e);
-            }
+            logger.debug("Found EngineProvider: {}", provider.getEngineName());
+            ALL_ENGINES.put(provider.getEngineName(), provider);
         }
 
         if (ALL_ENGINES.isEmpty()) {
@@ -81,14 +73,11 @@ public abstract class Engine {
         String defaultEngine = System.getenv("DJL_DEFAULT_ENGINE");
         defaultEngine = System.getProperty("ai.djl.default_engine", defaultEngine);
         if (defaultEngine == null || defaultEngine.isEmpty()) {
-            if (ALL_ENGINES.size() > 1) {
-                logger.warn("More than one deep learning engines found.");
-            }
             int rank = Integer.MAX_VALUE;
-            for (Engine engine : ALL_ENGINES.values()) {
-                if (engine.getRank() < rank) {
-                    defaultEngine = engine.getEngineName();
-                    rank = engine.getRank();
+            for (EngineProvider provider : ALL_ENGINES.values()) {
+                if (provider.getEngineRank() < rank) {
+                    defaultEngine = provider.getEngineName();
+                    rank = provider.getEngineRank();
                 }
             }
         } else if (!ALL_ENGINES.containsKey(defaultEngine)) {
@@ -123,8 +112,7 @@ public abstract class Engine {
             throw new EngineException(
                     "No deep learning engine found."
                             + System.lineSeparator()
-                            + "Please refer to https://github.com/awslabs/djl/blob/master/docs/development/troubleshooting.md for more details.",
-                    exception);
+                            + "Please refer to https://github.com/awslabs/djl/blob/master/docs/development/troubleshooting.md for more details.");
         }
         return getEngine(System.getProperty("ai.djl.default_engine", DEFAULT_ENGINE));
     }
@@ -157,11 +145,11 @@ public abstract class Engine {
      * @see EngineProvider
      */
     public static Engine getEngine(String engineName) {
-        Engine engine = ALL_ENGINES.get(engineName);
-        if (engine == null) {
+        EngineProvider provider = ALL_ENGINES.get(engineName);
+        if (provider == null) {
             throw new IllegalArgumentException("Deep learning engine not found: " + engineName);
         }
-        return engine;
+        return provider.getEngine();
     }
 
     /**
@@ -281,15 +269,15 @@ public abstract class Engine {
         System.out.println("-------------- Directories --------------");
         try {
             Path temp = Paths.get(System.getProperty("java.io.tmpdir"));
-            System.out.println("temp directory: " + temp.toString());
+            System.out.println("temp directory: " + temp);
             Path tmpFile = Files.createTempFile("test", ".tmp");
             Files.delete(tmpFile);
 
             Path cacheDir = Utils.getCacheDir();
-            System.out.println("DJL cache directory: " + cacheDir.toAbsolutePath().toString());
+            System.out.println("DJL cache directory: " + cacheDir.toAbsolutePath());
 
             Path path = Utils.getEngineCacheDir();
-            System.out.println("Engine cache directory: " + path.toAbsolutePath().toString());
+            System.out.println("Engine cache directory: " + path.toAbsolutePath());
             Files.createDirectories(path);
             if (!Files.isWritable(path)) {
                 System.out.println("Engine cache directory is not writable!!!");
@@ -316,12 +304,13 @@ public abstract class Engine {
         System.out.println();
         System.out.println("----------------- Engines ---------------");
         System.out.println("Default Engine: " + DEFAULT_ENGINE);
-        for (Engine engine : ALL_ENGINES.values()) {
-            System.out.println(engine);
-        }
-        if (exception != null) {
-            System.out.println("Last error:");
-            exception.printStackTrace(System.out);
+        for (EngineProvider provider : ALL_ENGINES.values()) {
+            System.out.println(provider.getEngineName() + ": " + provider.getEngineRank());
+            try {
+                provider.getEngine();
+            } catch (EngineException e) {
+                e.printStackTrace(System.out);
+            }
         }
     }
 }

--- a/api/src/main/java/ai/djl/engine/EngineProvider.java
+++ b/api/src/main/java/ai/djl/engine/EngineProvider.java
@@ -28,6 +28,20 @@ package ai.djl.engine;
 public interface EngineProvider {
 
     /**
+     * Returns the name of the {@link Engine}.
+     *
+     * @return the name of {@link Engine}
+     */
+    String getEngineName();
+
+    /**
+     * Returns the rank of the {@link Engine}.
+     *
+     * @return the rank of {@link Engine}
+     */
+    int getEngineRank();
+
+    /**
      * Returns the instance of the {@link Engine} class EngineProvider should bind to.
      *
      * @return the instance of {@link Engine}

--- a/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrEngine.java
+++ b/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrEngine.java
@@ -32,6 +32,7 @@ import ai.djl.training.GradientCollector;
 public final class DlrEngine extends Engine {
 
     public static final String ENGINE_NAME = "DLR";
+    static final int RANK = 10;
 
     private Engine alternativeEngine;
 
@@ -69,7 +70,7 @@ public final class DlrEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public int getRank() {
-        return 10;
+        return RANK;
     }
 
     /** {@inheritDoc} */

--- a/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrEngineProvider.java
+++ b/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrEngineProvider.java
@@ -17,13 +17,28 @@ import ai.djl.engine.EngineProvider;
 
 /** {@code DlrEngineProvider} is the DLR implementation of {@link EngineProvider}. */
 public class DlrEngineProvider implements EngineProvider {
-    private static Engine engine;
+
+    private static volatile Engine engine; // NOPMD
 
     /** {@inheritDoc} */
     @Override
-    public synchronized Engine getEngine() {
+    public String getEngineName() {
+        return DlrEngine.ENGINE_NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getEngineRank() {
+        return DlrEngine.RANK;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getEngine() {
         if (engine == null) {
-            engine = DlrEngine.newInstance();
+            synchronized (this) {
+                engine = DlrEngine.newInstance();
+            }
         }
         return engine;
     }

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
@@ -40,6 +40,7 @@ import java.nio.file.Paths;
 public final class MxEngine extends Engine {
 
     public static final String ENGINE_NAME = "MXNet";
+    static final int RANK = 1;
     private static final String MXNET_EXTRA_LIBRARY_VERBOSE = "MXNET_EXTRA_LIBRARY_VERBOSE";
 
     /** Constructs an MXNet Engine. */
@@ -87,7 +88,7 @@ public final class MxEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public int getRank() {
-        return 1;
+        return RANK;
     }
 
     /** {@inheritDoc} */

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngineProvider.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngineProvider.java
@@ -18,13 +18,27 @@ import ai.djl.engine.EngineProvider;
 /** {@code MxEngineProvider} is the MXNet implementation of {@link EngineProvider}. */
 public class MxEngineProvider implements EngineProvider {
 
-    private static Engine engine;
+    private static volatile Engine engine; // NOPMD
 
     /** {@inheritDoc} */
     @Override
-    public synchronized Engine getEngine() {
+    public String getEngineName() {
+        return MxEngine.ENGINE_NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getEngineRank() {
+        return 0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getEngine() {
         if (engine == null) {
-            engine = MxEngine.newInstance();
+            synchronized (this) {
+                engine = MxEngine.newInstance();
+            }
         }
         return engine;
     }

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtEngine.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtEngine.java
@@ -31,6 +31,7 @@ import ai.onnxruntime.OrtEnvironment;
 public final class OrtEngine extends Engine {
 
     public static final String ENGINE_NAME = "OnnxRuntime";
+    static final int RANK = 10;
 
     private Engine alternativeEngine;
     private OrtEnvironment env;
@@ -53,7 +54,7 @@ public final class OrtEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public int getRank() {
-        return 10;
+        return RANK;
     }
 
     private Engine getAlternativeEngine() {

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtEngineProvider.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtEngineProvider.java
@@ -18,13 +18,27 @@ import ai.djl.engine.EngineProvider;
 /** {@code OrtEngineProvider} is the ONNX Runtime implementation of {@link EngineProvider}. */
 public class OrtEngineProvider implements EngineProvider {
 
-    private static Engine engine;
+    private static volatile Engine engine; // NOPMD
 
     /** {@inheritDoc} */
     @Override
-    public synchronized Engine getEngine() {
+    public String getEngineName() {
+        return OrtEngine.ENGINE_NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getEngineRank() {
+        return 10;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getEngine() {
         if (engine == null) {
-            engine = OrtEngine.newInstance();
+            synchronized (this) {
+                engine = OrtEngine.newInstance();
+            }
         }
         return engine;
     }

--- a/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpEngine.java
+++ b/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpEngine.java
@@ -31,6 +31,7 @@ import ai.djl.training.GradientCollector;
 public final class PpEngine extends Engine {
 
     public static final String ENGINE_NAME = "PaddlePaddle";
+    static final int RANK = 10;
 
     private Engine alternativeEngine;
     private String version;
@@ -53,7 +54,7 @@ public final class PpEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public int getRank() {
-        return 10;
+        return RANK;
     }
 
     Engine getAlternativeEngine() {

--- a/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpEngineProvider.java
+++ b/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpEngineProvider.java
@@ -18,13 +18,27 @@ import ai.djl.engine.EngineProvider;
 /** {@code PpEngineProvider} is the PaddlePaddle implementation of {@link EngineProvider}. */
 public class PpEngineProvider implements EngineProvider {
 
-    private static Engine engine;
+    private static volatile Engine engine; // NOPMD
 
     /** {@inheritDoc} */
     @Override
-    public synchronized Engine getEngine() {
+    public String getEngineName() {
+        return PpEngine.ENGINE_NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getEngineRank() {
+        return PpEngine.RANK;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getEngine() {
         if (engine == null) {
-            engine = PpEngine.newInstance();
+            synchronized (this) {
+                engine = PpEngine.newInstance();
+            }
         }
         return engine;
     }

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
@@ -37,6 +37,7 @@ public final class PtEngine extends Engine {
     private static final Logger logger = LoggerFactory.getLogger(PtEngine.class);
 
     public static final String ENGINE_NAME = "PyTorch";
+    static final int RANK = 2;
 
     private PtEngine() {}
 
@@ -67,7 +68,7 @@ public final class PtEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public int getRank() {
-        return 2;
+        return RANK;
     }
 
     /** {@inheritDoc} */

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngineProvider.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngineProvider.java
@@ -18,13 +18,27 @@ import ai.djl.engine.EngineProvider;
 /** {@code PtEngineProvider} is the PyTorch implementation of {@link EngineProvider}. */
 public class PtEngineProvider implements EngineProvider {
 
-    private static Engine engine;
+    private static volatile Engine engine; // NOPMD
 
     /** {@inheritDoc} */
     @Override
-    public synchronized Engine getEngine() {
+    public String getEngineName() {
+        return PtEngine.ENGINE_NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getEngineRank() {
+        return PtEngine.RANK;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getEngine() {
         if (engine == null) {
-            engine = PtEngine.newInstance();
+            synchronized (this) {
+                engine = PtEngine.newInstance();
+            }
         }
         return engine;
     }

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
@@ -42,6 +42,7 @@ import org.tensorflow.internal.c_api.global.tensorflow;
 public final class TfEngine extends Engine implements AutoCloseable {
 
     public static final String ENGINE_NAME = "TensorFlow";
+    static final int RANK = 3;
 
     private static AtomicReference<TFE_Context> eagerSessionHandle;
 
@@ -85,7 +86,7 @@ public final class TfEngine extends Engine implements AutoCloseable {
     /** {@inheritDoc} */
     @Override
     public int getRank() {
-        return 3;
+        return RANK;
     }
 
     /** {@inheritDoc} */

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngineProvider.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngineProvider.java
@@ -17,13 +17,27 @@ import ai.djl.engine.EngineProvider;
 
 public class TfEngineProvider implements EngineProvider {
 
-    private static Engine engine;
+    private static volatile Engine engine; // NOPMD
 
     /** {@inheritDoc} */
     @Override
-    public synchronized Engine getEngine() {
+    public String getEngineName() {
+        return TfEngine.ENGINE_NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getEngineRank() {
+        return TfEngine.RANK;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getEngine() {
         if (engine == null) {
-            engine = TfEngine.newInstance();
+            synchronized (this) {
+                engine = TfEngine.newInstance();
+            }
         }
         return engine;
     }

--- a/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteEngine.java
+++ b/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteEngine.java
@@ -30,6 +30,7 @@ import ai.djl.training.GradientCollector;
 public final class TfLiteEngine extends Engine {
 
     public static final String ENGINE_NAME = "TFLite";
+    static final int RANK = 10;
 
     private Engine alternativeEngine;
 
@@ -50,7 +51,7 @@ public final class TfLiteEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public int getRank() {
-        return 10;
+        return RANK;
     }
 
     private Engine getAlternativeEngine() {

--- a/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteEngineProvider.java
+++ b/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteEngineProvider.java
@@ -18,13 +18,27 @@ import ai.djl.engine.EngineProvider;
 /** {@code TfLiteEngineProvider} is the TFLite implementation of {@link EngineProvider}. */
 public class TfLiteEngineProvider implements EngineProvider {
 
-    private static Engine engine;
+    private static volatile Engine engine; // NOPMD
 
     /** {@inheritDoc} */
     @Override
-    public synchronized Engine getEngine() {
+    public String getEngineName() {
+        return TfLiteEngine.ENGINE_NAME;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getEngineRank() {
+        return TfLiteEngine.RANK;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getEngine() {
         if (engine == null) {
-            engine = TfLiteEngine.newInstance();
+            synchronized (this) {
+                engine = TfLiteEngine.newInstance();
+            }
         }
         return engine;
     }

--- a/tools/conf/findbugs-exclude.xml
+++ b/tools/conf/findbugs-exclude.xml
@@ -27,11 +27,6 @@
         <Method name="forwardInternal"/>
     </Match>
     <Match>
-        <Bug pattern="DC_DOUBLECHECK"/>
-        <Class name="~ai\.djl\.tensorflow\.engine\.TfSymbolBlock"/>
-        <Method name="forwardInternal"/>
-    </Match>
-    <Match>
         <Bug pattern="URF_UNREAD_FIELD"/>
         <Class name="~ai\.djl\.pytorch\.engine\.PtNDArray"/>
     </Match>


### PR DESCRIPTION
## Description ##

In current implementation, all the engines are initialized at the beginning. This behavior isn't ideal when multiple engine jar files are included in the project. Some project may not need all the engines at runtime. This change provide flexibility that allows a project include all the jars in the class and only load required engine when needed.
