### PR TITLE
[pytorch] Use 1.8.1 release version of pytorch native

### DIFF
--- a/dlr/dlr-engine/build.gradle
+++ b/dlr/dlr-engine/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation "org.slf4j:slf4j-simple:${slf4j_version}"
     testRuntimeOnly project(":pytorch:pytorch-engine")
     testRuntimeOnly "ai.djl.dlr:dlr-native-auto:${dlr_version}"
-    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
 }
 
 processResources {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     if (System.getProperty("ai.djl.default_engine") == "PyTorch") {
         runtimeOnly project(":pytorch:pytorch-model-zoo")
-        runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+        runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
     } else if (System.getProperty("ai.djl.default_engine") == "TensorFlow") {
         runtimeOnly project(":tensorflow:tensorflow-model-zoo")
         runtimeOnly "ai.djl.tensorflow:tensorflow-native-auto:${tensorflow_version}"

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     runtimeOnly project(":mxnet:mxnet-model-zoo")
     runtimeOnly "ai.djl.mxnet:mxnet-native-auto:${mxnet_version}"
     runtimeOnly project(":pytorch:pytorch-model-zoo")
-    runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+    runtimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
     runtimeOnly project(":tensorflow:tensorflow-model-zoo")
     runtimeOnly "ai.djl.tensorflow:tensorflow-native-auto:${tensorflow_version}"
 

--- a/ml/xgboost/build.gradle
+++ b/ml/xgboost/build.gradle
@@ -8,7 +8,7 @@ configurations {
 
 dependencies {
     api project(":api")
-    api("ml.dmlc:xgboost4j_2.12:${xgboost_version}"){
+    api("ml.dmlc:xgboost4j_2.12:${xgboost_version}") {
         // get rid of the unused XGBoost Dependencies
         exclude group: "org.apache.hadoop", module: "hadoop-hdfs"
         exclude group: "org.apache.hadoop", module: "hadoop-common"
@@ -30,7 +30,7 @@ dependencies {
     }
 
 //    testRuntimeOnly project(":pytorch:pytorch-engine")
-//    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+//    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
     testRuntimeOnly "org.slf4j:slf4j-simple:${slf4j_version}"
 }
 

--- a/onnxruntime/onnxruntime-engine/build.gradle
+++ b/onnxruntime/onnxruntime-engine/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     }
 
     // testRuntimeOnly project(":pytorch:pytorch-engine")
-    // testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+    // testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
     testRuntimeOnly "org.slf4j:slf4j-simple:${slf4j_version}"
 }
 

--- a/paddlepaddle/paddlepaddle-model-zoo/build.gradle
+++ b/paddlepaddle/paddlepaddle-model-zoo/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation "org.slf4j:slf4j-simple:${slf4j_version}"
     testRuntimeOnly "ai.djl.paddlepaddle:paddlepaddle-native-auto:${paddlepaddle_version}"
     testRuntimeOnly project(":pytorch:pytorch-engine")
-    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
 }
 
 task syncS3(type: Exec) {

--- a/pytorch/pytorch-engine/build.gradle
+++ b/pytorch/pytorch-engine/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     }
     testImplementation "org.slf4j:slf4j-simple:${slf4j_version}"
     testRuntimeOnly project(":pytorch:pytorch-model-zoo")
-    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}-SNAPSHOT"
+    testRuntimeOnly "ai.djl.pytorch:pytorch-native-auto:${pytorch_version}"
 }
 
 processResources {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
